### PR TITLE
Add utils unit tests; minor bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+test/exec.log
+
+.vscode/

--- a/scutout/utils.py
+++ b/scutout/utils.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 ##################################################
-###          MODULE IMPORT
+# MODULE IMPORT
 ##################################################
-## STANDARD MODULES
+# STANDARD MODULES
 import os
 import sys
 import string
@@ -13,9 +13,9 @@ import fnmatch
 import shutil
 import errno
 
-## ASTRO MODULES
+# ASTRO MODULES
 from astropy.io import fits
-from astropy.io import ascii 
+from astropy.io import ascii
 from astropy.wcs import WCS
 from astropy.nddata import Cutout2D
 from astropy.stats import sigma_clipped_stats
@@ -24,969 +24,987 @@ from astropy.coordinates import SkyCoord
 from regions import CircleAnnulusSkyRegion, CircleAnnulusPixelRegion
 import montage_wrapper as montage
 
-## GRAPHICS MODULES
-#import matplotlib.pyplot as plt
+# GRAPHICS MODULES
+# import matplotlib.pyplot as plt
 
 
 logger = logging.getLogger(__name__)
 
 
 ###########################
-##     CLASS DEFINITIONS
+# CLASS DEFINITIONS
 ###########################
 class Utils(object):
-	""" Class collecting utility methods
-
-			Attributes:
-				None
-	"""
-
-	def __init__(self):
-		""" Return a Utils object """
-		
-	@classmethod
-	def getBaseFile(cls,filename):
-		""" Get basefilename without extension """
-		filename_base= os.path.basename(filename)
-		return filename_base
-
-	@classmethod
-	def getBaseFileNoExt(cls,filename):
-		""" Get basefilename without extension """
-		filename_base= os.path.basename(filename)
-		filename_base_noext= os.path.splitext(filename_base)[0]
-		return filename_base_noext
-
-	@classmethod
-	def mkdir(cls,path):
-		""" Create a directory """
-		try:
-			os.makedirs(path)
-		except OSError as exc:
-			if exc.errno != errno.EEXIST:
-				logger.error('Failed to create directory ' + path + '!')
-				return -1
-		return 0
-
-	@classmethod
-	def has_patterns_in_string(cls,s,patterns):
-		""" Return true if patterns are found in string """
-		if not patterns:		
-			return False
-
-		found= False
-		for pattern in patterns:
-			found= pattern in s
-			if found:
-				break
-
-		return found
-
-	@classmethod
-	def find_file(cls,rootPath,searched_file):
-		""" Find file recursively from root directory and return full path """
-		matches = []
-		for root, dirnames, filenames in os.walk(rootPath):
-			for filename in fnmatch.filter(filenames, searched_file):
-				matches.append(os.path.join(root, filename))
-
-		return matches
-
-	@classmethod
-	def find_and_copy_file(cls,rootPath,searched_file,destDir):
-		""" Find file recursively from root dir and move to destination dir """
-
-		matched_files= Utils.find_file(rootPath,searched_file)
-		if not matched_files:
-			return -1
-
-		for filename in matched_files:
-			shutil.copy(filename, destDir)
-
-		return 0
-
-	@classmethod
-	def write_ascii(cls,data,filename,header=''):
-		""" Write data to ascii file """
-
-		# - Skip if data is empty
-		if data.size<=0:
-			#cls._logger.warn("Empty data given, no file will be written!")
-			logger.warn("Empty data given, no file will be written!")
-			return
-
-		# - Open file and write header
-		fout = open(filename, 'wt')
-		if header:
-			fout.write(header)
-			fout.write('\n')	
-			fout.flush()	
-		
-		# - Write data to file
-		nrows= data.shape[0]
-		ncols= data.shape[1]
-		for i in range(nrows):
-			fields= '  '.join(map(str, data[i,:]))
-			fout.write(fields)
-			fout.write('\n')	
-			fout.flush()	
-
-		fout.close();
-
-	@classmethod
-	def read_ascii(cls,filename,skip_patterns=[]):
-		""" Read an ascii file line by line """
-	
-		try:
-			f = open(filename, 'r')
-		except IOError:
-			errmsg= 'Could not read file: ' + filename
-			#cls._logger.error(errmsg)
-			logger.error(errmsg)
-			raise IOError(errmsg)
-
-		fields= []
-		for line in f:
-			line = line.strip()
-			line_fields = line.split()
-			if not line_fields:
-				continue
-
-			# Skip pattern
-			skipline= cls.has_patterns_in_string(line_fields[0],skip_patterns)
-			if skipline:
-				continue 		
-
-			fields.append(line_fields)
-
-		f.close()	
-
-		return fields
-
-	@classmethod
-	def read_ascii_table(cls,filename,row_start=0,delimiter='|',format=''):
-		""" Read an ascii table file line by line """
-
-		try:
-			if format:
-				table= ascii.read(filename,format=format)
-			else:
-				table= ascii.read(filename,data_start=row_start, delimiter=delimiter)
-		except Exception as ex:
-			logger.error("Failed to read table!")
-			return None			
-
-		return table
-
-	@classmethod
-	def write_fits(cls,data,filename,header=None):
-		""" Read data to FITS image """
-
-		if header:
-			hdu= fits.PrimaryHDU(data,header)
-		else:
-			hdu= fits.PrimaryHDU(data)
-
-		hdul= fits.HDUList([hdu])
-		hdul.writeto(filename,overwrite=True)
-
-	@classmethod
-	def read_fits(cls,filename):
-		""" Read FITS image and return data """
-
-		# - Open file
-		try:
-			hdu= fits.open(filename,memmap=False)
-		except Exception as ex:
-			errmsg= 'Cannot read image file: ' + filename
-			#cls._logger.error(errmsg)
-			logger.error(errmsg)
-			raise IOError(errmsg)
-
-		# - Read data
-		data= hdu[0].data
-		data_size= np.shape(data)
-		nchan= len(data.shape)
-		if nchan==4:
-			output_data= data[0,0,:,:]
-		elif nchan==2:
-			output_data= data	
-		else:
-			errmsg= 'Invalid/unsupported number of channels found in file ' + filename + ' (nchan=' + str(nchan) + ')!'
-			#cls._logger.error(errmsg)
-			logger.error(errmsg)
-			hdu.close()
-			raise IOError(errmsg)
-
-		# - Read metadata
-		header= hdu[0].header
-
-		# - Close file
-		hdu.close()
-
-		return output_data, header
-
-	
-	@classmethod
-	def crop_img(cls,data,x0,y0,dx,dy):
-		""" Extract sub image of size (dx,dy) around pixel (x0,y0) """
-
-		#- Extract crop data
-		xmin= int(x0-dx/2)
-		xmax= int(x0+dx/2)
-		ymin= int(y0-dy/2)
-		ymax= int(y0+dy/2)		
-		crop_data= data[ymin:ymax+1,xmin:xmax+1]
-	
-		#- Replace NAN with zeros and inf with large numbers
-		np.nan_to_num(crop_data,False)
-
-		return crop_data
-
-	@classmethod
-	def getBeamArea(cls,bmaj,bmin):
-		""" Compute beam area """
-		beamArea= np.pi * bmaj * bmin/(4.*np.log(2))
-		return beamArea
-
-	@classmethod
-	def getNVSSSurveyBeamArea(cls):
-		""" Returns NVSS survey beam area """ 
-		bmaj= 45. # arcsec
-		bmin= 45. # arcsec
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-	@classmethod
-	def getWiseSurveyBeamArea(cls,band):
-		""" Returns Wise survey beam area """ 
-		if band=='wise_3_4':
-			bmaj= 8.5 # arcsec
-			bmin= 8.5 # arcsec
-		elif band=='wise_4_6':
-			bmaj= 8.5 # arcsec
-			bmin= 8.5 # arcsec
-		elif band=='wise_12':
-			bmaj= 8.5 # arcsec
-			bmin= 8.5 # arcsec
-		elif band=='wise_22':
-			bmaj= 17 # arcsec
-			bmin= 17 # arcsec
-		else:
-			logger.error("Invalid/unknown band argument given (" + band + ")!")
-			return 0
-		
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-	@classmethod
-	def getIRACSurveyBeamArea(cls,band):
-		""" Returns IRAC survey beam area """ 
-		if band=='irac_3_6':
-			bmaj= 1.7 # arcsec
-			bmin= 1.7 # arcsec
-		elif band=='irac_4_5':
-			bmaj= 1.7 # arcsec
-			bmin= 1.7 # arcsec
-		elif band=='irac_5_8':
-			bmaj= 1.7 # arcsec
-			bmin= 1.7 # arcsec
-		elif band=='irac_8':
-			bmaj= 1.9 # arcsec
-			bmin= 1.9 # arcsec
-		else:
-			logger.error("Invalid/unknown band argument given (" + band + ")!")
-			return 0
-		
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-	@classmethod
-	def getMIPSSurveyBeamArea(cls):
-		""" Returns MIPS survey beam area """ 
-		
-		bmaj= 6 # arcsec
-		bmin= 6 # arcsec
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-	@classmethod
-	def getHiGalSurveyBeamArea(cls,band):
-		""" Returns HiGal survey beam area """ 
-		if band=='higal_70':
-			bmaj= 8.512 # arcsec
-			bmin= 8.512 # arcsec
-		elif band=='higal_160':
-			bmaj= 12.103 # arcsec
-			bmin= 12.103 # arcsec
-		elif band=='higal_250':
-			bmaj= 18 # arcsec
-			bmin= 18 # arcsec
-		elif band=='higal_350':
-			bmaj= 24 # arcsec
-			bmin= 24 # arcsec
-		elif band=='higal_500':
-			bmaj= 34.5 # arcsec
-			bmin= 34.5 # arcsec
-		else:
-			logger.error("Invalid/unknown band argument given (" + band + ")!")
-			return 0
-		
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-	@classmethod
-	def getATLASGALSurveyBeamArea(cls):
-		""" Returns ATLASGAL survey beam area """ 
-
-		bmaj= 18.6 # arcsec (from http://www.apex-telescope.org/bolometer/laboca/technical/)
-		bmin= 18.6 # arcsec (from http://www.apex-telescope.org/bolometer/laboca/technical/)
-		#bmaj= 19.2 # arcsec (from ATLASGAL papers)
-		#bmin= 19.2 # arcsec (from ATLASGAL papers)
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-	@classmethod
-	def getATLASGALPlanckSurveyBeamArea(cls):
-		""" Returns ATLASGAL+Planck survey beam area """ 
-
-		bmaj= 21 # arcsec (from http://atlasgal.mpifr-bonn.mpg.de/cgi-bin/ATLASGAL_DATASETS.cgi)
-		bmin= 21 # arcsec 
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-	@classmethod
-	def getMSXSurveyBeamArea(cls):
-		""" Returns MSX survey beam area """ 
-
-		bmaj= 20 # arcsec
-		bmin= 20 # arcsec
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-	@classmethod
-	def getFIRSTSurveyBeamArea(cls,ra,dec):
-		""" Returns FIRST survey beam area """ 
-		
-		if not ra or not dec:
-			bmaj= 5.4
-			bmin= 5.4
-
-		if dec>4.55583333:
-			bmaj= 5.4
-			bmin= 5.4
-		else:
-			if dec<-2.50694444 and (ra<45 or ra>315):
-				bmaj= 6.8
-				bmin= 5.4
-			else:
-				bmaj= 6.4
-				bmin= 5.4
-
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-	@classmethod
-	def getMGPSSurveyBeamArea(cls,dec):
-		""" Returns MGPS survey beam area """ 
-		
-		if not dec or dec==0:
-			bmaj= 43
-		else:
-			bmaj= 43./np.sin(np.deg2rad(dec)) # arcsec
-		bmin= 43. # arcsec
-
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-
-	@classmethod
-	def getSGPSSurveyBeamArea(cls):
-		""" Returns SGPS survey beam area """ 
-		
-		# - Taken from SGPS images
-		#   NB: In https://iopscience.iop.org/article/10.1086/430114/pdf slightly different values (depending on l/b) are given
-		bmin= 100. # arcsec
-		bmaj= 100. # arcsec
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-	@classmethod
-	def getVGPSSurveyBeamArea(cls):
-		""" Returns VGPS survey beam area """ 
-		
-		# - Taken from https://iopscience.iop.org/article/10.1086/505940/pdf
-		bmin= 45. # arcsec
-		bmaj= 45. # arcsec
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-	@classmethod
-	def getScorpioATCASurveyBeamArea(cls,band):
-		""" Returns Scorpio ATCA survey beam area """ 
-		
-		if band=='scorpio_atca_2_1':
-			bmaj= 9.8 # arcsec
-			bmin= 5.8 # arcsec
-		#elif band=='scorpio_atca_5_0':
-		#	bmaj= 12.103 # arcsec
-		#	bmin= 12.103 # arcsec
-		
-		else:
-			logger.error("Invalid/unknown band argument given (" + band + ")!")
-			return 0
-		
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-	@classmethod
-	def getScorpioASKAPB1SurveyBeamArea(cls):
-		""" Returns Scorpio ASKAP 15 B1 survey beam area """ 
-		bmaj= 24 # arcsec
-		bmin= 21 # arcsec
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-	@classmethod
-	def getScorpioASKAP36B123SurveyBeamArea(cls):
-		""" Returns Scorpio ASKAP 36 B123 survey beam area """ 
-		bmaj= 9.403 # arcsec
-		bmin= 7.713 # arcsec
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-	@classmethod
-	def getTHORSurveyBeamArea(cls):
-		""" Returns THOR survey beam area """ 
-		#Beam varying from 18.1 x 11.1 to 12.0 x 11.6
-		bmaj= 12 # arcsec
-		bmin= 12 # arcsec
-		bmaj_deg= bmaj/3600.
-		bmin_deg= bmin/3600.
-		beamArea= Utils.getBeamArea(bmaj_deg,bmin_deg)
-		return beamArea
-
-	@classmethod
-	def getSurveyBeamArea(cls,survey,ra=None,dec=None):
-		""" Return beam area of given survey """
-		
-		beamArea= 0
-		if survey=='nvss':
-			beamArea= Utils.getNVSSSurveyBeamArea()
-		elif survey=='first':
-			beamArea= Utils.getFIRSTSurveyBeamArea(ra,dec)
-		elif survey=='mgps':
-			beamArea= Utils.getMGPSSurveyBeamArea(dec)
-		elif survey=='sgps':
-			beamArea= Utils.getSGPSSurveyBeamArea()
-		elif survey=='vgps':
-			beamArea= Utils.getVGPSSurveyBeamArea()
-		elif survey=='wise_3_4':
-			beamArea= Utils.getWiseSurveyBeamArea(survey)
-		elif survey=='wise_5_6':
-			beamArea= Utils.getWiseSurveyBeamArea(survey)
-		elif survey=='wise_12':
-			beamArea= Utils.getWiseSurveyBeamArea(survey)
-		elif survey=='wise_22':
-			beamArea= Utils.getWiseSurveyBeamArea(survey)
-		elif survey=='irac_3_6':
-			beamArea= Utils.getIRACSurveyBeamArea(survey)
-		elif survey=='irac_4_5':
-			beamArea= Utils.getIRACSurveyBeamArea(survey)
-		elif survey=='irac_5_8':
-			beamArea= Utils.getIRACSurveyBeamArea(survey)
-		elif survey=='irac_8':
-			beamArea= Utils.getIRACSurveyBeamArea(survey)
-		elif survey=='mips_24':
-			beamArea= Utils.getMIPSSurveyBeamArea()		
-		elif survey=='higal_70':
-			beamArea= Utils.getHiGalSurveyBeamArea(survey)
-		elif survey=='higal_160':
-			beamArea= Utils.getHiGalSurveyBeamArea(survey)
-		elif survey=='higal_250':
-			beamArea= Utils.getHiGalSurveyBeamArea(survey)
-		elif survey=='higal_350':
-			beamArea= Utils.getHiGalSurveyBeamArea(survey)
-		elif survey=='higal_500':
-			beamArea= Utils.getHiGalSurveyBeamArea(survey)
-		elif survey=='atlasgal':
-			beamArea= Utils.getATLASGALSurveyBeamArea()
-		elif survey=='atlasgal_planck':
-			beamArea= Utils.getATLASGALPlanckSurveyBeamArea()
-		elif survey=='msx_8_3':
-			beamArea= Utils.getMSXSurveyBeamArea()
-		elif survey=='msx_12_1':
-			beamArea= Utils.getMSXSurveyBeamArea()
-		elif survey=='msx_14_7':
-			beamArea= Utils.getMSXSurveyBeamArea()
-		elif survey=='msx_21_3':
-			beamArea= Utils.getMSXSurveyBeamArea()
-		elif survey=='scorpio_atca_2_1':
-			beamArea= Utils.getScorpioATCASurveyBeamArea(survey)
-		elif survey=='scorpio_askap15_b1':
-			beamArea= Utils.getScorpioASKAP15B1SurveyBeamArea()
-		elif survey=='scorpio_askap36_b123':
-			beamArea= Utils.getScorpioASKAP36B123SurveyBeamArea()
-		elif survey=='thor':
-			beamArea= Utils.getTHORSurveyBeamArea()
-		else:
-			logger.error("Unknown survey (" + survey + "), returning area=0!")
-			beamArea= 0
-
-		return beamArea
-
-	@classmethod
-	def getJyBeamToPixel(cls,beamArea,dx,dy):
-		""" Compute conversion factor from Jy/beam to Jy/pixel """
-
-		pixArea= np.abs(dx*dy)
-		toJyPerPix = pixArea/beamArea
-
-		return toJyPerPix
-
-	@classmethod
-	def getJyBeamToPixel2(cls,bmaj,bmin,dx,dy):
-		""" Compute conversion factor from Jy/beam to Jy/pixel """
-		beamArea= Utils.getBeamArea(bmaj,bmin)
-		return Utils.getJyBeamToPixel(beamArea,dx,dy)
-
-	@classmethod
-	def hasBeamInfo(cls,header):
-		""" Check if header has beam information """
-		hasBmaj= ('BMAJ' in header)
-		hasBmin= ('BMIN' in header)
-		hasBeamInfo= (hasBmaj and hasBmin)
-		if not hasBeamInfo:
-			return False
-		
-		hasBeamVal= (header['BMAJ'] and header['BMIN'])
-		if not hasBeamVal:
-			return False
-
-		return True
-
-
-	@classmethod
-	def fixImgAxisAndUnits(cls,filename,outfile):
-		""" Fix image axis issues and convert units """
-
-		# - Open input file
-		try:
-			hdu= fits.open(filename,memmap=False)
-		except Exception as ex:
-			logger.error('Cannot read image file: ' + filename)
-			return -1
-
-		# - Read data & header
-		header= hdu[0].header
-		data= hdu[0].data
-		data_size= np.shape(data)
-		nchan= len(data.shape)
-		if nchan==4:
-			output_data= data[0,0,:,:]
-			output_header= header
-			output_header['NAXIS']= 2
-
-		elif nchan==2:
-			output_data= data	
-			output_header= header
-			
-		else:
-			errmsg= 'Invalid/unsupported number of channels found in file ' + filename + ' (nchan=' + str(nchan) + ')!'
-			hdu.close()
-			logger.error(errmsg)
-			return -1
-
-		logger.info("Deleting NAXIS3/NAXIS4 from header...")
-		if 'NAXIS3' in output_header:
-			del output_header['NAXIS3']
-		if 'NAXIS4' in output_header:
-			del output_header['NAXIS4']
-		
-		if 'CTYPE3' in output_header:
-			del output_header['CTYPE3']
-		if 'CRVAL3' in output_header:
-			del output_header['CRVAL3']
-		if 'CDELT3' in output_header:
-			del output_header['CDELT3']
-		if 'CRPIX3' in output_header:
-			del output_header['CRPIX3']
-		if 'CROTA3' in output_header:
-			del output_header['CROTA3']
-		
-		if 'CTYPE4' in output_header:
-			del output_header['CTYPE4']
-		if 'CRVAL4' in output_header:
-			del output_header['CRVAL4']
-		if 'CDELT4' in output_header:
-			del output_header['CDELT4']
-		if 'CRPIX4' in output_header:
-			del output_header['CRPIX4']
-		if 'CROTA4' in output_header:
-			del output_header['CROTA4']
-
-		# - Close input file
-		hdu.close()
-
-		# - Scale flux?
-		bscale= 1
-		bzero= 0
-		if 'BZERO' in output_header:
-			bzero= output_header['BZERO']
-		if 'BSCALE' in output_header:
-			bscale= output_header['BSCALE']
-
-		if bzero!=0 or bscale!=1:
-			logger.info("Scaling image " + filename + " flux by bscale=" + str(bscale) + ", bzero=" + str(bzero) + " ...")
-			output_data_scaled= bzero + bscale*output_data
-			output_data= output_data_scaled
-			output_header['BSCALE']= 1
-			output_header['BZERO']= 0
-			
-		
-		# - Add missing BMAJ/BMIN to header?	
-		# ...
-	
-		
-		# - Convert data to float 32
-		output_data= output_data.astype(np.float32)
-
-		# - Write "fixed" fits
-		Utils.write_fits(output_data,outfile,output_header)
-
-		return 0
-
-
-	@classmethod
-	def fromBrightnessTempToJyBeam(cls,nu_GHz,bmin_arcsec,bmaj_arcsec):
-		""" Convert flux density from brightness temperature to Jy/beam """
-
-		# - Taken from https://science.nrao.edu/facilities/vla/proposing/TBconv
-		#T= 1.222e+3*I/(nu_GHz*nu_GHz*bmin_arcsec*bmaj_arcsec)
-		I_mJyBeam= nu_GHz*nu_GHz*bmin_arcsec*bmaj_arcsec/1.222e+3
-		I_JyBeam= I_mJyBeam*1.e-3
-		return I_JyBeam
-
-
-	@classmethod
-	def convertImgToJyPixel(cls,filename,outfile,survey=''):
-		""" Convert image units from original to Jy/pixel """
-
-		# - Read fits image
-		data, header= Utils.read_fits(filename)
-		wcs = WCS(header)
-
-		# - Check header keywords
-		if not header['BUNIT']:
-			logger.error("No BUNIT keyword present in file " + filename + ", cannot compute conversion factor!")
-			return -1
-		if not header['CDELT1']:
-			logger.error("No CDELT1 keyword present in file " + filename + ", cannot compute conversion factor!")
-			return -1
-		if not header['CDELT2']:
-			logger.error("No CDELT2 keyword present in file " + filename + ", cannot compute conversion factor!")
-			return -1
-		if not header['CRPIX1']:
-			logger.error("No CRPIX1 keyword present in file " + filename + ", cannot compute conversion factor!")
-			return -1
-		if not header['CRPIX2']:
-			logger.error("No CRPIX2 keyword present in file " + filename + ", cannot compute conversion factor!")
-			return -1
-		
-		units= header['BUNIT']
-		dx= header['CDELT1'] # in deg
-		dy= header['CDELT2'] # in deg
-		xc= header['CRPIX1']
-		yc= header['CRPIX2']	
-		ra, dec = wcs.all_pix2world(xc,yc,0,ra_dec_order=True)
-		
-		#==================
-		# - Convert data
-		#==================
-		convFactor= 1
-		
-		# - Jy/beam units (e.g. radio maps, apex)
-		if units=='JY/BEAM' or units=='Jy/beam':
-			
-			hasBeamInfo= Utils.hasBeamInfo(header)
-			if hasBeamInfo:
-				bmaj= header['BMAJ'] # in deg
-				bmin= header['BMIN'] # in deg
-				convFactor= Utils.getJyBeamToPixel2(bmaj,bmin,dx,dy)
-			else:
-				logger.warn("No BMAJ/BMIN keyword present in file " + filename + ", trying to retrieve from survey name...")
-				beamArea= Utils.getSurveyBeamArea(survey,ra,dec)
-				if beamArea>0:
-					convFactor= Utils.getJyBeamToPixel(beamArea,dx,dy)
-				else:
-					logger.error("No BMAJ keyword present in file " + filename + ", cannot compute conversion factor!")
-					return -1
-		
-		# - DN UNITS (e.g WISE MAPS)
-		elif units=='DN':
-			if survey=='wise_3_4':
-				convFactor= 1.9350E-06
-			elif survey=='wise_4_6':
-				convFactor= 2.7048E-06
-			elif survey=='wise_12':
-				convFactor= 1.8326e-06
-			elif survey=='wise_22':
-				convFactor= 5.2269E-05
-			else:
-				logger.error("Invalid or unknown survey (" + survey + ") given!")
-				return -1
-
-		# - MJy/sr units (e.g. HERSCHEL/SPITZER maps)
-		elif units=='MJy/sr':
-			convFactor= 1.e+6*dx*dy/(206265.*206265.)
-
-		# - W/m^2-sr units (e.g. MSX maps)
-		elif units=='W/m^2-sr':
-			convFactor_fromJyToSr= dx*dy/(206265.*206265.)
-			if survey=='msx_8_3':
-				convFactor= 7.133e+12*convFactor_fromJyToSr
-			elif survey=='msx_12_1':
-				convFactor= 2.863e+13*convFactor_fromJyToSr
-			elif survey=='msx_14_7':
-				convFactor= 3.216e+13*convFactor_fromJyToSr
-			elif survey=='msx_21_3':
-				convFactor= 2.476e+13*convFactor_fromJyToSr
-			else:
-				logger.error("Invalid or unknown survey (" + survey + ") given!")
-				return -1
-
-		# - T units (e.g. VGPS)
-		elif units=='K':
-			if survey=='vgps':
-				nu= 1.4 # GHz
-				bmaj= 45 # arcsec
-				bmin= 45 # arcsec
-				convFactor= Utils.fromBrightnessTempToJyBeam(nu,bmin,bmaj)
-			else:
-				logger.error("Invalid or unknown survey (" + survey + ") given!")
-				return -1
-
-		# - Jy/pixel units (e.g. simulated maps)
-		elif units=='Jy/pixel' or units=='JY/PIXEL':
-			convFactor= 1
-		else:
-			logger.error('Units ' + units + ' not recognized!')
-			return -1	
-						
-		# - Scale data
-		data_conv= data*convFactor
-		header_conv= header	
-
-		# - Edit header
-		header_conv['BUNIT']= 'Jy/pixel'
-
-		# - Write converted fits to file
-		Utils.write_fits(data_conv,outfile,header_conv)
-
-		return 0
-
-	@classmethod
-	def cropImage(cls,filename,ra,dec,crop_size,outfile,source_size=-1,nanfill=True,nanfill_mode='imgmin',nanfill_val=0):
-		""" Crop image around (ra,dec) by crop_size """
-
-		# - Read fits image
-		data, header= Utils.read_fits(filename)
-		wcs = WCS(header)
-		dx= header['CDELT1'] # in deg
-		dy= header['CDELT2'] # in deg
-		pix_size= max(dx,dy) # in deg
-
-		# - Check if crop size is cutting part of the source
-		if source_size!=-1:
-			source_size_pix= source_size/pix_size
-			if source_size_pix>=crop_size:
-				logger.warn("Requested crop size (%d) exceeding source size (size=%d arcsec, %d pix), won't write cropped fits file!" % (crop_size,source_size*3600,source_size_pix))
-				return -1
-
-		# - Find pixel coordinates corresponding to ra,dec
-		x0, y0 = wcs.all_world2pix(ra,dec,0,ra_dec_order=True)
-
-		# - Extract cutout. With option 'partial' when cutout size is larger than image size the cutout will be filled with nan (or specified value)
-		cutout= Cutout2D(data, (x0,y0), (crop_size,crop_size), mode='partial',wcs=wcs)
-		output_data= cutout.data
-
-		# - Fill NAN?
-		if nanfill:
-			if nanfill_mode=='imgmin':
-				img_min= np.nanmin(output_data)
-				output_data[np.isnan(output_data)]= img_min	
-			else:
-				output_data[np.isnan(output_data)]= nanfill_val
-			
-		# - Write reshaped image fits
-		Utils.write_fits(output_data,outfile)
-		
-		return 0
-
-	@classmethod
-	def estimateBkgFromAnnulus(cls,filename,ra,dec,R1,R2,method='sigmaclip',max_nan_thr=0.1):
-		""" Estimate bkg from annulus around given sky position """
-
-		# - Read fits image
-		data, header= Utils.read_fits(filename)
-		wcs = WCS(header)	
-
-		# - Define sky annulus region
-		center= SkyCoord(ra*u.deg,dec*u.deg,frame='fk5')
-		annulus_sky = CircleAnnulusSkyRegion(	
-			center=center,
-			inner_radius=R1*u.arcsec,	
-			outer_radius=R2*u.arcsec
-		)
-
-		# - Convert sky annulus to pixel annulus
-		annulus_pix= annulus_sky.to_pixel(wcs)
-
-		# - Get mask corresponding to annulus and array of pixel values in the mask
-		mask= annulus_pix.to_mask()
-		mask_data= mask.to_image(shape=data.shape)
-		aperture_pixel_data= data[mask_data==1]
-		
-		# - Integrity check before computing stats
-		npixels= aperture_pixel_data.size
-		if npixels==0:
-			logger.warn("Pixel mask is empty, returning zero!")
-			return 0
-
-		nan_counts= np.count_nonzero(np.isnan(aperture_pixel_data))
-		nan_fract= float(nan_counts)/float(npixels) 
-		if nan_fract>max_nan_thr:
-			logger.warn("Fraction of nan pixels in mask (%s) exceeding max threshold (%s), returning zero!" % (str(nan_fract),str(max_nan_thr)))
-			return 0
-		
-		# - Compute median or 3-sigma clipped value as bkg estimator
-		bkg= 0
-		nsigma= 3
-		if method=='median':
-			bkg= np.median(aperture_pixel_data)
-		elif method=='sigmaclip':
-			mean,median,rms= sigma_clipped_stats(aperture_pixel_data,sigma=nsigma)
-			bkg= median
-		else:
-			logger.error("Invalid bkg estimation method (%s) given, returning zero!" % (method))
-			return -1			
-
-		return bkg
-
-	@classmethod
-	def makeMosaic(cls,input_tbl,output,combine="mean",background_match=False,bitpix=-32,exact= False):
-		""" Create a mosaic from input images """
-
-		# - Get output file base dir
-		outdir= os.path.dirname(output)
-
-		# - Get current directory and create work dir
-		currdir = os.path.dirname(os.path.realpath(input_tbl))
-		input_tbl_base= Utils.getBaseFileNoExt(input_tbl)
-		workdir= 'mosaic_' + input_tbl_base 
-		dir_path= os.path.join(currdir, workdir)
-		Utils.mkdir(dir_path) 
-		
-		# - Computing optimal header
-		logger.info("Mosaicing: computing optimal header ...")
-		
-		header_tbl= input_tbl_base + '.hdr'
-		header_tbl_fullpath= os.path.join(dir_path,header_tbl)
-		montage.mMakeHdr(images_table=input_tbl, template_header=header_tbl_fullpath)
-        
-		# - Projecting raw frames
-		logger.info("Mosaicing: projecting raw frames ...")
-		stats_tbl= input_tbl_base + '_stats.tbl'
-		stats_tbl_fullpath= os.path.join(dir_path,stats_tbl)
-		
-		montage.mProjExec(
-			images_table=input_tbl, 
-			template_header=header_tbl_fullpath, 
-			proj_dir=dir_path, 
-			stats_table=stats_tbl_fullpath,
-			exact=exact
-		)
-
-		# - List projected frames
-		logger.info("Mosaicing: listing projected frames ...")
-		projimg_tbl= input_tbl_base + '_proj.tbl'
-		projimg_tbl_fullpath= os.path.join(dir_path,projimg_tbl)
-		res = montage.mImgtbl(dir_path, projimg_tbl_fullpath)
-		if res.count == 0:
-			logger.error("Mosaicing: No images were successfully projected!")
-			return -1
-		
-		# - Compute overlap if background_match is enabled
-		if background_match:
-			logger.info("Mosaicing: determining overlaps ...")
-			diffs_tbl= input_tbl_base + '_diffs.tbl'
-			diffs_tbl_fullpath= os.path.join(dir_path,diffs_tbl)
-			res = montage.mOverlaps(projimg_tbl_fullpath, diffs_tbl_fullpath)
-			if res.count == 0:
-				logger.info("Mosaicing: no overlapping frames, backgrounds will not be adjusted")
-				background_match = False
-
-		# - Make mosaic
-		if background_match:
-			logger.error("Mosaicing with background_match not yet implemented!")
-			return -1
-
-		else:
-			# - Mosaicking frames
-			logger.info("Mosaicing: adding frames ...")
-			mosaic_file= input_tbl_base + '_mosaic64.fits'
-			mosaic_file_fullpath= os.path.join(dir_path,mosaic_file)
-			montage.mAdd(
-				projimg_tbl_fullpath, 
-				header_tbl_fullpath,
-				mosaic_file_fullpath,
-				img_dir=dir_path, 
-				type=combine, 
-				exact=exact
-			)
-
-			
-		# - Converting mosaic file to desired format
-		logger.info("Mosaicing: converting mosaic file to desired format (type=%s) ..." % (bitpix))
-		montage.mConvert(mosaic_file_fullpath,output,bitpix=bitpix)
-
-		# - Converting mosaic area file to desired format
-		mosaic_area_file= input_tbl_base + '_mosaic64_area.fits'
-		mosaic_area_file_fullpath= os.path.join(dir_path,mosaic_area_file)
-		output_base= Utils.getBaseFileNoExt(output)
-		mosaic_area_outfile= output_base + '_area.fits'
-		mosaic_area_outfile_fullpath= os.path.join(outdir,mosaic_area_outfile)
-		montage.mConvert(mosaic_area_file_fullpath,mosaic_area_outfile_fullpath,bitpix=bitpix)
-
-		return 0
-
+    """ Class collecting utility methods
+
+                    Attributes:
+                            None
+    """
+
+    def __init__(self):
+        """ Return a Utils object """
+
+    @classmethod
+    def getBaseFile(cls, filename):
+        """ Get basefilename without extension """
+        filename_base = os.path.basename(filename)
+        return filename_base
+
+    @classmethod
+    def getBaseFileNoExt(cls, filename):
+        """ Get basefilename without extension """
+        filename_base = os.path.basename(filename)
+        filename_base_noext = os.path.splitext(filename_base)[0]
+        return filename_base_noext
+
+    @classmethod
+    def mkdir(cls, path):
+        """ Create a directory """
+        try:
+            os.makedirs(path)
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                logger.error('Failed to create directory ' + path + '!')
+                return -1
+        return 0
+
+    @classmethod
+    def has_patterns_in_string(cls, s, patterns):
+        """ Return true if patterns are found in string """
+        if not patterns:
+            return False
+
+        found = False
+        for pattern in patterns:
+            found = pattern in s
+            if found:
+                break
+
+        return found
+
+    @classmethod
+    def find_file(cls, rootPath, searched_file):
+        """ Find file recursively from root directory and return full path """
+        matches = []
+        for root, dirnames, filenames in os.walk(rootPath):
+            for filename in fnmatch.filter(filenames, searched_file):
+                matches.append(os.path.join(root, filename))
+        return matches
+
+    @classmethod
+    def find_and_copy_file(cls, rootPath, searched_file, destDir):
+        """ Find file recursively from root dir and move to destination dir """
+
+        matched_files = Utils.find_file(rootPath, searched_file)
+        if not matched_files:
+            return -1
+
+        for filename in matched_files:
+            shutil.copy(filename, destDir)
+
+        return 0
+
+    @classmethod
+    def write_ascii(cls, data, filename, header=''):
+        """ Write data to ascii file """
+
+        # - Skip if data is empty
+        if data.size <= 0:
+            # cls._logger.warn("Empty data given, no file will be written!")
+            logger.warning("Empty data given, no file will be written!")
+            return
+
+        # - Open file and write header
+        fout = open(filename, 'wt')
+        if header:
+            fout.write(header)
+            fout.write('\n')
+            fout.flush()
+
+        # - Write data to file
+        nrows = data.shape[0]
+        ncols = data.shape[1]
+        for i in range(nrows):
+            fields = '  '.join(map(str, data[i, :]))
+            fout.write(fields)
+            fout.write('\n')
+            fout.flush()
+
+        fout.close()
+
+    @classmethod
+    def read_ascii(cls, filename, skip_patterns=[]):
+        """ Read an ascii file line by line """
+
+        try:
+            f = open(filename, 'r')
+        except IOError:
+            errmsg = 'Could not read file: ' + filename
+            # cls._logger.error(errmsg)
+            logger.error(errmsg)
+            raise IOError(errmsg)
+
+        fields = []
+        for line in f:
+            line = line.strip()
+            line_fields = line.split()
+            if not line_fields:
+                continue
+
+            # Skip pattern
+            skipline = cls.has_patterns_in_string(
+                line_fields[0], skip_patterns)
+            if skipline:
+                continue
+
+            fields.append(line_fields)
+
+        f.close()
+
+        return fields
+
+    @classmethod
+    def read_ascii_table(cls, filename, row_start=0, delimiter='|', format=''):
+        """ Read an ascii table file line by line """
+
+        try:
+            if format:
+                table = ascii.read(filename, format=format)
+            else:
+                table = ascii.read(
+                    filename, data_start=row_start, delimiter=delimiter)
+        except Exception as ex:
+            logger.error("Failed to read table!")
+            return None
+
+        return table
+
+    @classmethod
+    def write_fits(cls, data, filename, header=None):
+        """ Read data to FITS image """
+        if header:
+            hdu = fits.PrimaryHDU(data, header)
+        else:
+            hdu = fits.PrimaryHDU(data)
+
+        hdul = fits.HDUList([hdu])
+        hdul.writeto(filename, overwrite=True)
+
+    @classmethod
+    def read_fits(cls, filename):
+        """ Read FITS image and return data """
+
+        # - Open file
+        try:
+            hdu = fits.open(filename, memmap=False)
+        except Exception as ex:
+            errmsg = 'Cannot read image file: ' + filename
+            # cls._logger.error(errmsg)
+            logger.error(errmsg)
+            raise IOError(errmsg)
+
+        # - Read data
+        data = hdu[0].data
+        data_size = np.shape(data)
+        nchan = len(data.shape)
+        if nchan == 4:
+            output_data = data[0, 0, :, :]
+        elif nchan == 2:
+            output_data = data
+        else:
+            errmsg = 'Invalid/unsupported number of channels found in file ' + \
+                filename + ' (nchan=' + str(nchan) + ')!'
+            # cls._logger.error(errmsg)
+            logger.error(errmsg)
+            hdu.close()
+            raise IOError(errmsg)
+
+        # - Read metadata
+        header = hdu[0].header
+
+        # - Close file
+        hdu.close()
+
+        return output_data, header
+
+    @classmethod
+    def crop_img(cls, data, x0, y0, dx, dy):
+        """ Extract sub image of size (dx,dy) around pixel (x0,y0) """
+
+        # - Extract crop data
+        xmin = int(x0-dx/2)
+        xmax = int(x0+dx/2)
+        ymin = int(y0-dy/2)
+        ymax = int(y0+dy/2)
+        crop_data = data[ymin:ymax+1, xmin:xmax+1]
+
+        # - Replace NAN with zeros and inf with large numbers
+        np.nan_to_num(crop_data, False)
+
+        return crop_data
+
+    @classmethod
+    def getBeamArea(cls, bmaj, bmin):
+        """ Compute beam area """
+        beamArea = np.pi * bmaj * bmin/(4.*np.log(2))
+        return beamArea
+
+    @classmethod
+    def getNVSSSurveyBeamArea(cls):
+        """ Returns NVSS survey beam area """
+        bmaj = 45.  # arcsec
+        bmin = 45.  # arcsec
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getWiseSurveyBeamArea(cls, band):
+        """ Returns Wise survey beam area """
+        if band == 'wise_3_4':
+            bmaj = 8.5  # arcsec
+            bmin = 8.5  # arcsec
+        elif band == 'wise_4_6':
+            bmaj = 8.5  # arcsec
+            bmin = 8.5  # arcsec
+        elif band == 'wise_12':
+            bmaj = 8.5  # arcsec
+            bmin = 8.5  # arcsec
+        elif band == 'wise_22':
+            bmaj = 17  # arcsec
+            bmin = 17  # arcsec
+        else:
+            logger.error("Invalid/unknown band argument given (" + band + ")!")
+            return 0
+
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getIRACSurveyBeamArea(cls, band):
+        """ Returns IRAC survey beam area """
+        if band == 'irac_3_6':
+            bmaj = 1.7  # arcsec
+            bmin = 1.7  # arcsec
+        elif band == 'irac_4_5':
+            bmaj = 1.7  # arcsec
+            bmin = 1.7  # arcsec
+        elif band == 'irac_5_8':
+            bmaj = 1.7  # arcsec
+            bmin = 1.7  # arcsec
+        elif band == 'irac_8':
+            bmaj = 1.9  # arcsec
+            bmin = 1.9  # arcsec
+        else:
+            logger.error("Invalid/unknown band argument given (" + band + ")!")
+            return 0
+
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getMIPSSurveyBeamArea(cls):
+        """ Returns MIPS survey beam area """
+
+        bmaj = 6  # arcsec
+        bmin = 6  # arcsec
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getHiGalSurveyBeamArea(cls, band):
+        """ Returns HiGal survey beam area """
+        if band == 'higal_70':
+            bmaj = 8.512  # arcsec
+            bmin = 8.512  # arcsec
+        elif band == 'higal_160':
+            bmaj = 12.103  # arcsec
+            bmin = 12.103  # arcsec
+        elif band == 'higal_250':
+            bmaj = 18  # arcsec
+            bmin = 18  # arcsec
+        elif band == 'higal_350':
+            bmaj = 24  # arcsec
+            bmin = 24  # arcsec
+        elif band == 'higal_500':
+            bmaj = 34.5  # arcsec
+            bmin = 34.5  # arcsec
+        else:
+            logger.error("Invalid/unknown band argument given (" + band + ")!")
+            return 0
+
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getATLASGALSurveyBeamArea(cls):
+        """ Returns ATLASGAL survey beam area """
+
+        # arcsec (from http://www.apex-telescope.org/bolometer/laboca/technical/)
+        bmaj = 18.6
+        # arcsec (from http://www.apex-telescope.org/bolometer/laboca/technical/)
+        bmin = 18.6
+        # bmaj= 19.2 # arcsec (from ATLASGAL papers)
+        # bmin= 19.2 # arcsec (from ATLASGAL papers)
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getATLASGALPlanckSurveyBeamArea(cls):
+        """ Returns ATLASGAL+Planck survey beam area """
+
+        # arcsec (from http://atlasgal.mpifr-bonn.mpg.de/cgi-bin/ATLASGAL_DATASETS.cgi)
+        bmaj = 21
+        bmin = 21  # arcsec
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getMSXSurveyBeamArea(cls):
+        """ Returns MSX survey beam area """
+
+        bmaj = 20  # arcsec
+        bmin = 20  # arcsec
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getFIRSTSurveyBeamArea(cls, ra, dec):
+        """ Returns FIRST survey beam area """
+
+        if not ra or not dec:
+            bmaj = 5.4
+            bmin = 5.4
+
+        if dec > 4.55583333:
+            bmaj = 5.4
+            bmin = 5.4
+        else:
+            if dec < -2.50694444 and (ra < 45 or ra > 315):
+                bmaj = 6.8
+                bmin = 5.4
+            else:
+                bmaj = 6.4
+                bmin = 5.4
+
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getMGPSSurveyBeamArea(cls, dec):
+        """ Returns MGPS survey beam area """
+
+        if not dec or dec == 0:
+            bmaj = 43
+        else:
+            bmaj = 43./np.sin(np.deg2rad(dec))  # arcsec
+        bmin = 43.  # arcsec
+
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getSGPSSurveyBeamArea(cls):
+        """ Returns SGPS survey beam area """
+
+        # - Taken from SGPS images
+        #   NB: In https://iopscience.iop.org/article/10.1086/430114/pdf slightly different values (depending on l/b) are given
+        bmin = 100.  # arcsec
+        bmaj = 100.  # arcsec
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getVGPSSurveyBeamArea(cls):
+        """ Returns VGPS survey beam area """
+
+        # - Taken from https://iopscience.iop.org/article/10.1086/505940/pdf
+        bmin = 45.  # arcsec
+        bmaj = 45.  # arcsec
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getScorpioATCASurveyBeamArea(cls, band):
+        """ Returns Scorpio ATCA survey beam area """
+
+        if band == 'scorpio_atca_2_1':
+            bmaj = 9.8  # arcsec
+            bmin = 5.8  # arcsec
+        # elif band=='scorpio_atca_5_0':
+        #	bmaj= 12.103 # arcsec
+        #	bmin= 12.103 # arcsec
+
+        else:
+            logger.error("Invalid/unknown band argument given (" + band + ")!")
+            return 0
+
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getScorpioASKAP15B1SurveyBeamArea(cls):
+        """ Returns Scorpio ASKAP 15 B1 survey beam area """
+        bmaj = 24  # arcsec
+        bmin = 21  # arcsec
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getScorpioASKAP36B123SurveyBeamArea(cls):
+        """ Returns Scorpio ASKAP 36 B123 survey beam area """
+        bmaj = 9.403  # arcsec
+        bmin = 7.713  # arcsec
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getTHORSurveyBeamArea(cls):
+        """ Returns THOR survey beam area """
+        # Beam varying from 18.1 x 11.1 to 12.0 x 11.6
+        bmaj = 12  # arcsec
+        bmin = 12  # arcsec
+        bmaj_deg = bmaj/3600.
+        bmin_deg = bmin/3600.
+        beamArea = Utils.getBeamArea(bmaj_deg, bmin_deg)
+        return beamArea
+
+    @classmethod
+    def getSurveyBeamArea(cls, survey, ra=None, dec=None):
+        """ Return beam area of given survey """
+
+        beamArea = 0
+        if survey == 'nvss':
+            beamArea = Utils.getNVSSSurveyBeamArea()
+        elif survey == 'first':
+            beamArea = Utils.getFIRSTSurveyBeamArea(ra, dec)
+        elif survey == 'mgps':
+            beamArea = Utils.getMGPSSurveyBeamArea(dec)
+        elif survey == 'sgps':
+            beamArea = Utils.getSGPSSurveyBeamArea()
+        elif survey == 'vgps':
+            beamArea = Utils.getVGPSSurveyBeamArea()
+        elif survey == 'wise_3_4':
+            beamArea = Utils.getWiseSurveyBeamArea(survey)
+        elif survey == 'wise_4_6':
+            beamArea = Utils.getWiseSurveyBeamArea(survey)
+        elif survey == 'wise_12':
+            beamArea = Utils.getWiseSurveyBeamArea(survey)
+        elif survey == 'wise_22':
+            beamArea = Utils.getWiseSurveyBeamArea(survey)
+        elif survey == 'irac_3_6':
+            beamArea = Utils.getIRACSurveyBeamArea(survey)
+        elif survey == 'irac_4_5':
+            beamArea = Utils.getIRACSurveyBeamArea(survey)
+        elif survey == 'irac_5_8':
+            beamArea = Utils.getIRACSurveyBeamArea(survey)
+        elif survey == 'irac_8':
+            beamArea = Utils.getIRACSurveyBeamArea(survey)
+        elif survey == 'mips_24':
+            beamArea = Utils.getMIPSSurveyBeamArea()
+        elif survey == 'higal_70':
+            beamArea = Utils.getHiGalSurveyBeamArea(survey)
+        elif survey == 'higal_160':
+            beamArea = Utils.getHiGalSurveyBeamArea(survey)
+        elif survey == 'higal_250':
+            beamArea = Utils.getHiGalSurveyBeamArea(survey)
+        elif survey == 'higal_350':
+            beamArea = Utils.getHiGalSurveyBeamArea(survey)
+        elif survey == 'higal_500':
+            beamArea = Utils.getHiGalSurveyBeamArea(survey)
+        elif survey == 'atlasgal':
+            beamArea = Utils.getATLASGALSurveyBeamArea()
+        elif survey == 'atlasgal_planck':
+            beamArea = Utils.getATLASGALPlanckSurveyBeamArea()
+        elif survey == 'msx_8_3':
+            beamArea = Utils.getMSXSurveyBeamArea()
+        elif survey == 'msx_12_1':
+            beamArea = Utils.getMSXSurveyBeamArea()
+        elif survey == 'msx_14_7':
+            beamArea = Utils.getMSXSurveyBeamArea()
+        elif survey == 'msx_21_3':
+            beamArea = Utils.getMSXSurveyBeamArea()
+        elif survey == 'scorpio_atca_2_1':
+            beamArea = Utils.getScorpioATCASurveyBeamArea(survey)
+        elif survey == 'scorpio_askap15_b1':
+            beamArea = Utils.getScorpioASKAP15B1SurveyBeamArea()
+        elif survey == 'scorpio_askap36_b123':
+            beamArea = Utils.getScorpioASKAP36B123SurveyBeamArea()
+        elif survey == 'thor':
+            beamArea = Utils.getTHORSurveyBeamArea()
+        else:
+            logger.error("Unknown survey (" + survey + "), returning area=0!")
+            beamArea = 0
+
+        return beamArea
+
+    @classmethod
+    def getJyBeamToPixel(cls, beamArea, dx, dy):
+        """ Compute conversion factor from Jy/beam to Jy/pixel """
+
+        pixArea = np.abs(dx*dy)
+        toJyPerPix = pixArea/beamArea
+
+        return toJyPerPix
+
+    @classmethod
+    def getJyBeamToPixel2(cls, bmaj, bmin, dx, dy):
+        """ Compute conversion factor from Jy/beam to Jy/pixel """
+        beamArea = Utils.getBeamArea(bmaj, bmin)
+        return Utils.getJyBeamToPixel(beamArea, dx, dy)
+
+    @classmethod
+    def hasBeamInfo(cls, header):
+        """ Check if header has beam information """
+        hasBmaj = ('BMAJ' in header)
+        hasBmin = ('BMIN' in header)
+        hasBeamInfo = (hasBmaj and hasBmin)
+        if not hasBeamInfo:
+            return False
+
+        hasBeamVal = (header['BMAJ'] and header['BMIN'])
+        if not hasBeamVal:
+            return False
+
+        return True
+
+    @classmethod
+    def fixImgAxisAndUnits(cls, filename, outfile):
+        """ Fix image axis issues and convert units """
+
+        # - Open input file
+        try:
+            hdu = fits.open(filename, memmap=False)
+        except Exception as ex:
+            logger.error('Cannot read image file: ' + filename)
+            return -1
+
+        # - Read data & header
+        header = hdu[0].header
+        data = hdu[0].data
+        data_size = np.shape(data)
+        nchan = len(data.shape)
+        if nchan == 4:
+            output_data = data[0, 0, :, :]
+            output_header = header
+            output_header['NAXIS'] = 2
+
+        elif nchan == 2:
+            output_data = data
+            output_header = header
+
+        else:
+            errmsg = 'Invalid/unsupported number of channels found in file ' + \
+                filename + ' (nchan=' + str(nchan) + ')!'
+            hdu.close()
+            logger.error(errmsg)
+            return -1
+
+        logger.info("Deleting NAXIS3/NAXIS4 from header...")
+        if 'NAXIS3' in output_header:
+            del output_header['NAXIS3']
+        if 'NAXIS4' in output_header:
+            del output_header['NAXIS4']
+
+        if 'CTYPE3' in output_header:
+            del output_header['CTYPE3']
+        if 'CRVAL3' in output_header:
+            del output_header['CRVAL3']
+        if 'CDELT3' in output_header:
+            del output_header['CDELT3']
+        if 'CRPIX3' in output_header:
+            del output_header['CRPIX3']
+        if 'CROTA3' in output_header:
+            del output_header['CROTA3']
+
+        if 'CTYPE4' in output_header:
+            del output_header['CTYPE4']
+        if 'CRVAL4' in output_header:
+            del output_header['CRVAL4']
+        if 'CDELT4' in output_header:
+            del output_header['CDELT4']
+        if 'CRPIX4' in output_header:
+            del output_header['CRPIX4']
+        if 'CROTA4' in output_header:
+            del output_header['CROTA4']
+
+        # - Close input file
+        hdu.close()
+
+        # - Scale flux?
+        bscale = 1
+        bzero = 0
+        if 'BZERO' in output_header:
+            bzero = output_header['BZERO']
+        if 'BSCALE' in output_header:
+            bscale = output_header['BSCALE']
+
+        if bzero != 0 or bscale != 1:
+            logger.info("Scaling image " + filename + " flux by bscale=" +
+                        str(bscale) + ", bzero=" + str(bzero) + " ...")
+            output_data_scaled = bzero + bscale*output_data
+            output_data = output_data_scaled
+            output_header['BSCALE'] = 1
+            output_header['BZERO'] = 0
+
+        # - Add missing BMAJ/BMIN to header?
+        # ...
+
+        # - Convert data to float 32
+        output_data = output_data.astype(np.float32)
+
+        # - Write "fixed" fits
+        Utils.write_fits(output_data, outfile, output_header)
+
+        return 0
+
+    @classmethod
+    def fromBrightnessTempToJyBeam(cls, nu_GHz, bmin_arcsec, bmaj_arcsec):
+        """ Convert flux density from brightness temperature to Jy/beam """
+
+        # - Taken from https://science.nrao.edu/facilities/vla/proposing/TBconv
+        # T= 1.222e+3*I/(nu_GHz*nu_GHz*bmin_arcsec*bmaj_arcsec)
+        I_mJyBeam = nu_GHz*nu_GHz*bmin_arcsec*bmaj_arcsec/1.222e+3
+        I_JyBeam = I_mJyBeam*1.e-3
+        return I_JyBeam
+
+    @classmethod
+    def convertImgToJyPixel(cls, filename, outfile, survey=''):
+        """ Convert image units from original to Jy/pixel """
+
+        # - Read fits image
+        data, header = Utils.read_fits(filename)
+        wcs = WCS(header)
+
+        # - Check header keywords
+        if not bool(header.get('BUNIT')):
+            logger.error("No BUNIT keyword present in file " +
+                         filename + ", cannot compute conversion factor!")
+            return -1
+        if not bool(header.get('CDELT1')):
+            logger.error("No CDELT1 keyword present in file " +
+                         filename + ", cannot compute conversion factor!")
+            return -1
+        if not bool(header.get('CDELT2')):
+            logger.error("No CDELT2 keyword present in file " +
+                         filename + ", cannot compute conversion factor!")
+            return -1
+        if not bool(header.get('CRPIX1')):
+            logger.error("No CRPIX1 keyword present in file " +
+                         filename + ", cannot compute conversion factor!")
+            return -1
+        if not bool(header.get('CRPIX2')):
+            logger.error("No CRPIX2 keyword present in file " +
+                         filename + ", cannot compute conversion factor!")
+            return -1
+
+        units = header['BUNIT']
+        dx = header['CDELT1']  # in deg
+        dy = header['CDELT2']  # in deg
+        xc = header['CRPIX1']
+        yc = header['CRPIX2']
+        ra, dec = wcs.all_pix2world(xc, yc, 0, ra_dec_order=True)
+
+        # ==================
+        # - Convert data
+        # ==================
+        convFactor = 1
+
+        # - Jy/beam units (e.g. radio maps, apex)
+        if units == 'JY/BEAM' or units == 'Jy/beam':
+
+            hasBeamInfo = Utils.hasBeamInfo(header)
+            if hasBeamInfo:
+                bmaj = header['BMAJ']  # in deg
+                bmin = header['BMIN']  # in deg
+                convFactor = Utils.getJyBeamToPixel2(bmaj, bmin, dx, dy)
+            else:
+                logger.warning("No BMAJ/BMIN keyword present in file " +
+                               filename + ", trying to retrieve from survey name...")
+                beamArea = Utils.getSurveyBeamArea(survey, ra, dec)
+                if beamArea > 0:
+                    convFactor = Utils.getJyBeamToPixel(beamArea, dx, dy)
+                else:
+                    logger.error("No BMAJ keyword present in file " +
+                                 filename + ", cannot compute conversion factor!")
+                    return -1
+
+        # - DN UNITS (e.g WISE MAPS)
+        elif units == 'DN':
+            if survey == 'wise_3_4':
+                convFactor = 1.9350E-06
+            elif survey == 'wise_4_6':
+                convFactor = 2.7048E-06
+            elif survey == 'wise_12':
+                convFactor = 1.8326e-06
+            elif survey == 'wise_22':
+                convFactor = 5.2269E-05
+            else:
+                logger.error(
+                    "Invalid or unknown survey (" + survey + ") given!")
+                return -1
+
+        # - MJy/sr units (e.g. HERSCHEL/SPITZER maps)
+        elif units == 'MJy/sr':
+            convFactor = 1.e+6*dx*dy/(206265.*206265.)
+
+        # - W/m^2-sr units (e.g. MSX maps)
+        elif units == 'W/m^2-sr':
+            convFactor_fromJyToSr = dx*dy/(206265.*206265.)
+            if survey == 'msx_8_3':
+                convFactor = 7.133e+12*convFactor_fromJyToSr
+            elif survey == 'msx_12_1':
+                convFactor = 2.863e+13*convFactor_fromJyToSr
+            elif survey == 'msx_14_7':
+                convFactor = 3.216e+13*convFactor_fromJyToSr
+            elif survey == 'msx_21_3':
+                convFactor = 2.476e+13*convFactor_fromJyToSr
+            else:
+                logger.error(
+                    "Invalid or unknown survey (" + survey + ") given!")
+                return -1
+
+        # - T units (e.g. VGPS)
+        elif units == 'K':
+            if survey == 'vgps':
+                nu = 1.4  # GHz
+                bmaj = 45  # arcsec
+                bmin = 45  # arcsec
+                convFactor = Utils.fromBrightnessTempToJyBeam(nu, bmin, bmaj)
+            else:
+                logger.error(
+                    "Invalid or unknown survey (" + survey + ") given!")
+                return -1
+
+        # - Jy/pixel units (e.g. simulated maps)
+        elif units == 'Jy/pixel' or units == 'JY/PIXEL':
+            convFactor = 1
+        else:
+            logger.error('Units ' + units + ' not recognized!')
+            return -1
+
+        # - Scale data
+        data_conv = data*convFactor
+        header_conv = header
+
+        # - Edit header
+        header_conv['BUNIT'] = 'Jy/pixel'
+
+        # - Write converted fits to file
+        Utils.write_fits(data_conv, outfile, header_conv)
+
+        return 0
+
+    @classmethod
+    def cropImage(cls, filename, ra, dec, crop_size, outfile, source_size=-1, nanfill=True, nanfill_mode='imgmin', nanfill_val=0):
+        """ Crop image around (ra,dec) by crop_size """
+
+        # - Read fits image
+        data, header = Utils.read_fits(filename)
+        wcs = WCS(header)
+        dx = header['CDELT1']  # in deg
+        dy = header['CDELT2']  # in deg
+        pix_size = max(dx, dy)  # in deg
+
+        # - Check if crop size is cutting part of the source
+        if source_size != -1:
+            source_size_pix = source_size/pix_size
+            if source_size_pix >= crop_size:
+                logger.warning("Requested crop size (%d) exceeding source size (size=%d arcsec, %d pix), won't write cropped fits file!" % (
+                    crop_size, source_size*3600, source_size_pix))
+                return -1
+
+        # - Find pixel coordinates corresponding to ra,dec
+        x0, y0 = wcs.all_world2pix(ra, dec, 0, ra_dec_order=True)
+
+        # - Extract cutout. With option 'partial' when cutout size is larger than image size the cutout will be filled with nan (or specified value)
+        cutout = Cutout2D(data, (x0, y0), (crop_size,
+                                           crop_size), mode='partial', wcs=wcs)
+        output_data = cutout.data
+
+        # - Fill NAN?
+        if nanfill:
+            if nanfill_mode == 'imgmin':
+                img_min = np.nanmin(output_data)
+                output_data[np.isnan(output_data)] = img_min
+            else:
+                output_data[np.isnan(output_data)] = nanfill_val
+
+        # - Write reshaped image fits
+        Utils.write_fits(output_data, outfile)
+
+        return 0
+
+    @classmethod
+    def estimateBkgFromAnnulus(cls, filename, ra, dec, R1, R2, method='sigmaclip', max_nan_thr=0.1):
+        """ Estimate bkg from annulus around given sky position """
+
+        # - Read fits image
+        data, header = Utils.read_fits(filename)
+        wcs = WCS(header)
+
+        # - Define sky annulus region
+        center = SkyCoord(ra*u.deg, dec*u.deg, frame='fk5')
+        annulus_sky = CircleAnnulusSkyRegion(
+            center=center,
+            inner_radius=R1*u.arcsec,
+            outer_radius=R2*u.arcsec
+        )
+
+        # - Convert sky annulus to pixel annulus
+        annulus_pix = annulus_sky.to_pixel(wcs)
+
+        # - Get mask corresponding to annulus and array of pixel values in the mask
+        mask = annulus_pix.to_mask()
+        mask_data = mask.to_image(shape=data.shape)
+        aperture_pixel_data = data[mask_data == 1]
+
+        # - Integrity check before computing stats
+        npixels = aperture_pixel_data.size
+        if npixels == 0:
+            logger.warning("Pixel mask is empty, returning zero!")
+            return 0
+
+        nan_counts = np.count_nonzero(np.isnan(aperture_pixel_data))
+        nan_fract = float(nan_counts)/float(npixels)
+        if nan_fract > max_nan_thr:
+            logger.warning("Fraction of nan pixels in mask (%s) exceeding max threshold (%s), returning zero!" % (
+                str(nan_fract), str(max_nan_thr)))
+            return 0
+
+        # - Compute median or 3-sigma clipped value as bkg estimator
+        bkg = 0
+        nsigma = 3
+        if method == 'median':
+            bkg = np.median(aperture_pixel_data)
+        elif method == 'sigmaclip':
+            mean, median, rms = sigma_clipped_stats(
+                aperture_pixel_data, sigma=nsigma)
+            bkg = median
+        else:
+            logger.error(
+                "Invalid bkg estimation method (%s) given, returning zero!" % (method))
+            return -1
+
+        return bkg
+
+    @classmethod
+    def makeMosaic(cls, input_tbl, output, combine="mean", background_match=False, bitpix=-32, exact=False):
+        """ Create a mosaic from input images """
+
+        # - Get output file base dir
+        outdir = os.path.dirname(output)
+
+        # - Get current directory and create work dir
+        currdir = os.path.dirname(os.path.realpath(input_tbl))
+        input_tbl_base = Utils.getBaseFileNoExt(input_tbl)
+        workdir = 'mosaic_' + input_tbl_base
+        dir_path = os.path.join(currdir, workdir)
+        Utils.mkdir(dir_path)
+
+        # - Computing optimal header
+        logger.info("Mosaicing: computing optimal header ...")
+
+        header_tbl = input_tbl_base + '.hdr'
+        header_tbl_fullpath = os.path.join(dir_path, header_tbl)
+        montage.mMakeHdr(images_table=input_tbl,
+                         template_header=header_tbl_fullpath)
+
+        # - Projecting raw frames
+        logger.info("Mosaicing: projecting raw frames ...")
+        stats_tbl = input_tbl_base + '_stats.tbl'
+        stats_tbl_fullpath = os.path.join(dir_path, stats_tbl)
+
+        montage.mProjExec(
+            images_table=input_tbl,
+            template_header=header_tbl_fullpath,
+            proj_dir=dir_path,
+            stats_table=stats_tbl_fullpath,
+            exact=exact
+        )
+
+        # - List projected frames
+        logger.info("Mosaicing: listing projected frames ...")
+        projimg_tbl = input_tbl_base + '_proj.tbl'
+        projimg_tbl_fullpath = os.path.join(dir_path, projimg_tbl)
+        res = montage.mImgtbl(dir_path, projimg_tbl_fullpath)
+        if res.count == 0:
+            logger.error("Mosaicing: No images were successfully projected!")
+            return -1
+
+        # - Compute overlap if background_match is enabled
+        if background_match:
+            logger.info("Mosaicing: determining overlaps ...")
+            diffs_tbl = input_tbl_base + '_diffs.tbl'
+            diffs_tbl_fullpath = os.path.join(dir_path, diffs_tbl)
+            res = montage.mOverlaps(projimg_tbl_fullpath, diffs_tbl_fullpath)
+            if res.count == 0:
+                logger.info(
+                    "Mosaicing: no overlapping frames, backgrounds will not be adjusted")
+                background_match = False
+
+        # - Make mosaic
+        if background_match:
+            logger.error(
+                "Mosaicing with background_match not yet implemented!")
+            raise NotImplementedError
+
+        else:
+            # - Mosaicking frames
+            logger.info("Mosaicing: adding frames ...")
+            mosaic_file = input_tbl_base + '_mosaic64.fits'
+            mosaic_file_fullpath = os.path.join(dir_path, mosaic_file)
+            montage.mAdd(
+                projimg_tbl_fullpath,
+                header_tbl_fullpath,
+                mosaic_file_fullpath,
+                img_dir=dir_path,
+                type=combine,
+                exact=exact
+            )
+
+        # - Converting mosaic file to desired format
+        logger.info(
+            "Mosaicing: converting mosaic file to desired format (type=%s) ..." % (bitpix))
+        montage.mConvert(mosaic_file_fullpath, output, bitpix=bitpix)
+
+        # - Converting mosaic area file to desired format
+        mosaic_area_file = input_tbl_base + '_mosaic64_area.fits'
+        mosaic_area_file_fullpath = os.path.join(dir_path, mosaic_area_file)
+        output_base = Utils.getBaseFileNoExt(output)
+        mosaic_area_outfile = output_base + '_area.fits'
+        mosaic_area_outfile_fullpath = os.path.join(
+            outdir, mosaic_area_outfile)
+        montage.mConvert(mosaic_area_file_fullpath,
+                         mosaic_area_outfile_fullpath, bitpix=bitpix)
+
+        return 0

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,0 +1,4 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../scutout')))
+import utils

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,977 @@
+import unittest
+import logging
+import builtins
+import copy
+import sys
+import numpy as np
+from astropy.io import fits
+from astropy import units as u
+from unittest.mock import patch
+from .context import utils
+
+
+class UtilsTest(unittest.TestCase):
+    """Tests for 'utils' package methods"""
+
+    @classmethod
+    def setUpClass(cls):
+        logging.basicConfig(filename='tests/exec.log',
+                            filemode='a', level=logging.WARNING)
+
+    def setUp(self):
+        self.utils = utils.Utils
+
+    def _createDummyFITS(self, ndim=2, radec=(0, 0), delt=0.00166667, size=512, bkg_mean=0, bkg_std=0.5, bunit='K'):
+        """ Creates dummy FITS file for testing purposes
+        Args:
+        - ndim:         number of dimensions
+        - radec:        tuple of RA, DEC in degrees (default=(0,0))
+        - delt:         RA, DEC increment in degrees (default=6'')
+        - size:         image size in pixels (default=512)
+        - bkg_mean:     background mean in brightness units (default=0)
+        """
+
+        data = bkg_mean + bkg_std * np.random.randn(size, size)
+        hdu = fits.PrimaryHDU(data)
+
+        # add world properties
+        hdu.header['CTYPE1'] = 'RA---TAN'
+        hdu.header['CTYPE2'] = 'DEC--TAN'
+        hdu.header['CRVAL1'] = radec[0]
+        hdu.header['CRVAL2'] = radec[1]
+        hdu.header['CDELT1'] = delt     # default 6''/px
+        hdu.header['CDELT2'] = -delt    # default 6''/px
+        hdu.header['CRPIX1'] = size/2
+        hdu.header['CRPIX2'] = size/2
+        hdu.header['EQUINOX'] = 2000.00
+
+        # add degenerate axes if needed
+        if (ndim > 2):
+            for idx in range(3, ndim+1):
+                hdu.data = np.expand_dims(hdu.data, axis=0)  # append axis
+                hdu.header['CTYPE' + str(idx)] = 'EXTRA'
+                hdu.header['CRVAL' + str(idx)] = '0'
+                hdu.header['CDELT' + str(idx)] = delt
+                hdu.header['CRPIX' + str(idx)] = 0
+                hdu.header['CROTA' + str(idx)] = 0
+
+        # add some additional default stuff
+        hdu.header['BUNIT'] = bunit
+        hdu.header['TELESCOP'] = 'TEST-TEL'
+        hdu.header['INSTRUME'] = 'TEST-INS'
+        hdu.header['DATE_OBS'] = '2001-01-01'
+        hdu.header['OBJECT'] = 'TEST-SOU'
+        return hdu
+
+    # Basic methods
+    def test_getBaseFile(self):
+        self.assertEqual(self.utils.getBaseFile('test.txt'), 'test.txt')
+        self.assertEqual(self.utils.getBaseFile(
+            '/usr/local/test.txt'), 'test.txt')
+        self.assertEqual(self.utils.getBaseFile('test'), 'test')
+
+    def test_getBaseFileNoExt(self):
+        self.assertEqual(self.utils.getBaseFileNoExt('test.txt'), 'test')
+        self.assertEqual(self.utils.getBaseFileNoExt(
+            '/usr/local/test.txt'), 'test')
+        self.assertEqual(self.utils.getBaseFileNoExt('test'), 'test')
+
+    def test_has_pattern_in_string(self):
+        self.assertTrue(self.utils.has_patterns_in_string('test_string', '_'))
+        # self.assertFalse(self.utils.has_patterns_in_string('test_string','test_string'))
+        self.assertFalse(self.utils.has_patterns_in_string('test_string', '?'))
+
+    def test_crop_img_Basic(self):
+        hdu = self._createDummyFITS()
+
+        x_max = hdu.shape[0]
+        y_max = hdu.shape[1]
+
+        crop = self.utils.crop_img(hdu.data, x_max/2, y_max/2, 10, 10)
+        self.assertEqual(crop.shape, (11, 11))
+
+        crop = self.utils.crop_img(hdu.data, x_max/2, y_max/2, 17, 25)
+        self.assertEqual(crop.shape, (26, 18))
+
+    def test_crop_img_OutOfBounds(self):
+        hdu = self._createDummyFITS()
+
+        x_max = hdu.shape[0]
+        y_max = hdu.shape[1]
+
+        crop = self.utils.crop_img(hdu.data, 0, 0, 10, 10)
+        self.assertEqual(crop.shape, (0, 0))
+        self.assertEqual(crop.shape, (0, 0))
+
+    # Test survey beams
+
+    def test_getBeamArea(self):
+        deg_conv = 1/3600
+        self.assertEqual(self.utils.getBeamArea(
+            1*deg_conv, 1*deg_conv), 8.742978668648137e-08)
+        self.assertEqual(self.utils.getBeamArea(0, 1*deg_conv), 0)
+        self.assertEqual(self.utils.getBeamArea(0, 0), 0)
+
+    def test_getNVSSSurveyBeamArea(self):
+        self.assertEqual(self.utils.getNVSSSurveyBeamArea(),
+                         0.00017704531804012478)
+
+    def test_getFIRSTSurveyBeamArea(self):
+        self.assertEqual(self.utils.getFIRSTSurveyBeamArea(
+            ra=0, dec=0), 3.021573427884796e-06)
+        self.assertEqual(self.utils.getFIRSTSurveyBeamArea(
+            ra=0, dec=5), 2.5494525797777964e-06)
+        self.assertEqual(self.utils.getFIRSTSurveyBeamArea(
+            ra=20, dec=-5), 3.2104217671275954e-06)
+        self.assertEqual(self.utils.getFIRSTSurveyBeamArea(
+            ra=320, dec=-5), 3.2104217671275954e-06)
+
+    def test_getMGPSSurveyBeamArea(self):
+        self.assertEqual(self.utils.getMGPSSurveyBeamArea(
+            dec=0), 0.00016165767558330406)
+        self.assertEqual(self.utils.getMGPSSurveyBeamArea(
+            dec=10), 0.0009309494505227407)
+
+    def test_getSGPSSurveyBeamArea(self):
+        self.assertEqual(self.utils.getSGPSSurveyBeamArea(),
+                         0.0008742978668648136)
+
+    def test_getVGPSSurveyBeamArea(self):
+        self.assertEqual(self.utils.getVGPSSurveyBeamArea(),
+                         0.00017704531804012478)
+
+    def test_getWiseSurveyBeamArea(self):
+        self.assertEqual(self.utils.getWiseSurveyBeamArea(
+            band='wise_3_4'),  6.316802088098279e-06)
+        self.assertEqual(self.utils.getWiseSurveyBeamArea(
+            band='wise_4_6'),  6.316802088098279e-06)
+        self.assertEqual(self.utils.getWiseSurveyBeamArea(
+            band='wise_12'),  6.316802088098279e-06)
+        self.assertEqual(self.utils.getWiseSurveyBeamArea(
+            band='wise_22'),  2.5267208352393116e-05)
+        self.assertEqual(self.utils.getWiseSurveyBeamArea(band='no_band'),  0)
+        self.assertEqual(self.utils.getWiseSurveyBeamArea(band=''),  0)
+
+    def test_getIRACSurveyBeamArea(self):
+        self.assertEqual(self.utils.getIRACSurveyBeamArea(
+            band='irac_3_6'), 2.526720835239311e-07)
+        self.assertEqual(self.utils.getIRACSurveyBeamArea(
+            band='irac_4_5'), 2.526720835239311e-07)
+        self.assertEqual(self.utils.getIRACSurveyBeamArea(
+            band='irac_5_8'), 2.526720835239311e-07)
+        self.assertEqual(self.utils.getIRACSurveyBeamArea(
+            band='irac_8'), 3.156215299381976e-07)
+        self.assertEqual(self.utils.getIRACSurveyBeamArea(band='no_band'),  0)
+        self.assertEqual(self.utils.getIRACSurveyBeamArea(band=''),  0)
+
+    def test_getMIPSSurveyBeamArea(self):
+        self.assertEqual(self.utils.getMIPSSurveyBeamArea(),
+                         3.147472320713329e-06)
+
+    def test_getHiGalSurveyBeamArea(self):
+        self.assertEqual(self.utils.getHiGalSurveyBeamArea(
+            band='higal_70'), 6.334650354471603e-06)
+        self.assertEqual(self.utils.getHiGalSurveyBeamArea(
+            band='higal_160'), 1.2806943258149252e-05)
+        self.assertEqual(self.utils.getHiGalSurveyBeamArea(
+            band='higal_250'), 2.8327250886419965e-05)
+        self.assertEqual(self.utils.getHiGalSurveyBeamArea(
+            band='higal_350'), 5.0359557131413266e-05)
+        self.assertEqual(self.utils.getHiGalSurveyBeamArea(
+            band='higal_500'), 0.00010406330360358443)
+        self.assertEqual(self.utils.getIRACSurveyBeamArea(band='no_band'),  0)
+        self.assertEqual(self.utils.getHiGalSurveyBeamArea(band=''),  0)
+
+    def test_getATLASGALSurveyBeamArea(self):
+        self.assertEqual(self.utils.getATLASGALSurveyBeamArea(),
+                         3.0247209002055094e-05)
+
+    def test_getATLASGALPlanckSurveyBeamArea(self):
+        self.assertEqual(
+            self.utils.getATLASGALPlanckSurveyBeamArea(), 3.8556535928738286e-05)
+
+    def test_getMSXSurveyBeamArea(self):
+        self.assertEqual(self.utils.getMSXSurveyBeamArea(),
+                         3.497191467459255e-05)
+
+    def test_getScorpioATCASurveyBeamArea(self):
+        self.assertEqual(self.utils.getScorpioATCASurveyBeamArea(
+            band='scorpio_atca_2_1'), 4.969509075259601e-06)
+        self.assertEqual(self.utils.getScorpioATCASurveyBeamArea(
+            band='scorpio_atca_5_0'), 0)  # Not implemented
+
+    def test_getScorpioASKAP15B1SurveyBeamArea(self):
+        self.assertEqual(
+            self.utils.getScorpioASKAP15B1SurveyBeamArea(), 4.4064612489986616e-05)
+
+    def test_getScorpioASKAP36B123SurveyBeamArea(self):
+        self.assertEqual(
+            self.utils.getScorpioASKAP36B123SurveyBeamArea(), 6.340874918134747e-06)
+
+    def test_getTHORSurveyBeamArea(self):
+        self.assertEqual(self.utils.getTHORSurveyBeamArea(),
+                         1.2589889282853316e-05)
+
+    def test_getSurveyBeamArea(self):
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'nvss'), 0.00017704531804012478)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'first', 0, 0), 3.021573427884796e-06)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'mgps', 0), 0.00016165767558330406)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'sgps'), 0.0008742978668648136)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'vgps'), 0.00017704531804012478)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'wise_3_4'), 6.316802088098279e-06)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'wise_4_6'), 6.316802088098279e-06)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'wise_12'), 6.316802088098279e-06)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'wise_22'), 2.5267208352393116e-05)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'irac_3_6'), 2.526720835239311e-07)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'irac_4_5'), 2.526720835239311e-07)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'irac_5_8'), 2.526720835239311e-07)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'irac_8'), 3.156215299381976e-07)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'mips_24'), 3.147472320713329e-06)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'higal_70'), 6.334650354471603e-06)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'higal_160'), 1.2806943258149252e-05)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'higal_250'), 2.8327250886419965e-05)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'higal_350'), 5.0359557131413266e-05)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'higal_500'), 0.00010406330360358443)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'atlasgal'),  3.0247209002055094e-05)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'atlasgal_planck'), 3.8556535928738286e-05)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'msx_8_3'), 3.497191467459255e-05)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'msx_12_1'), 3.497191467459255e-05)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'msx_14_7'), 3.497191467459255e-05)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'msx_21_3'), 3.497191467459255e-05)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'scorpio_atca_2_1'), 4.969509075259601e-06)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'scorpio_askap15_b1'), 4.4064612489986616e-05)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'scorpio_askap36_b123'), 6.340874918134747e-06)
+        self.assertEqual(self.utils.getSurveyBeamArea(
+            'thor'), 1.2589889282853316e-05)
+
+    # Helpers
+
+    def test_getJyBeamToPixel(self):
+        self.assertEqual(self.utils.getJyBeamToPixel(
+            beamArea=1e-8, dx=1e-9, dy=1e-9), 1e-10)
+        # negative dx/dy
+        self.assertEqual(self.utils.getJyBeamToPixel(
+            beamArea=1e-8, dx=-1e-9, dy=1e-9), 1e-10)
+        self.assertEqual(self.utils.getJyBeamToPixel(beamArea=0.011330900354567986,
+                                                     dx=0.1, dy=0.1), 0.8825424006106064)         # pxl size equal to bmaj, bmin
+        self.assertEqual(self.utils.getJyBeamToPixel2(
+            bmaj=0.1, bmin=0.1, dx=0.1, dy=0.1), 0.8825424006106064)                    # test overload
+
+    def test_hasBeamInfo_NoBeam(self):
+        hdu = self._createDummyFITS()
+        self.assertFalse(self.utils.hasBeamInfo(hdu.header))
+
+    def test_hasBeamInfo_EmptyBeam(self):
+        hdu = self._createDummyFITS()
+        hdu.header['BMAJ'] = ''
+        hdu.header['BMIN'] = ''
+        self.assertFalse(self.utils.hasBeamInfo(hdu.header))
+
+    def test_hasBeamInfo_BaseCase(self):
+        hdu = self._createDummyFITS()
+        hdu.header['BMAJ'] = 1
+        hdu.header['BMIN'] = 1
+        self.assertTrue(self.utils.hasBeamInfo(hdu.header))
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.fits.open')
+    def test_fixImgAxisAndUnits_Input2DFits(self, mock_read, mock_write):
+        hdu = self._createDummyFITS(ndim=2)         # dummy 2D fits
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        mock_read.return_value = fits.HDUList([hdu])
+        self.assertEqual(self.utils.fixImgAxisAndUnits(infile, outfile), 0)
+        assert mock_read.called
+        assert mock_write.called
+        fixed_hdu = mock_write.call_args[0]
+        fixed_hdu_data = fixed_hdu[0]
+        fixed_hdu_name = fixed_hdu[1]
+        fixed_hdu_head = fixed_hdu[2]
+
+        self.assertEqual(fixed_hdu_data.ndim, 2)        # check dimensions
+        self.assertEqual(fixed_hdu_name, outfile)       # check file name
+        self.assertEqual(fixed_hdu_head['NAXIS'], 2)    # check header
+        self.assertFalse('NAXIS3' in fixed_hdu_head)
+        self.assertFalse('CRVAL3' in fixed_hdu_head)
+        self.assertFalse('CRPIX3' in fixed_hdu_head)
+        self.assertFalse('CDELT3' in fixed_hdu_head)
+        self.assertFalse('CROTA3' in fixed_hdu_head)
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.fits.open')
+    def test_fixImgAxisAndUnits_Input3DFits(self, mock_read, mock_write):
+        hdu = self._createDummyFITS(ndim=3)         # dummy 3D fits
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        mock_read.return_value = fits.HDUList([hdu])
+
+        # invalid number of channels
+        self.assertEqual(self.utils.fixImgAxisAndUnits(infile, outfile), -1)
+        assert mock_read.called
+        assert not mock_write.called
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.fits.open')
+    def test_fixImgAxisAndUnits_Input4DFits(self, mock_read, mock_write):
+        hdu = self._createDummyFITS(size=512, ndim=4)         # dummy 4D fits
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        mock_read.return_value = fits.HDUList([hdu])
+
+        self.assertEqual(self.utils.fixImgAxisAndUnits(infile, outfile), 0)
+        assert mock_read.called
+        assert mock_write.called
+        fixed_hdu = mock_write.call_args[0]
+        fixed_hdu_data = fixed_hdu[0]
+        fixed_hdu_name = fixed_hdu[1]
+        fixed_hdu_head = fixed_hdu[2]
+
+        self.assertEqual(fixed_hdu_data.ndim, 2)        # check dimensions
+        self.assertEqual(fixed_hdu_data.shape, (512, 512))
+        self.assertEqual(fixed_hdu_name, outfile)       # check file name
+        self.assertEqual(fixed_hdu_head['NAXIS'], 2)    # check header
+        self.assertFalse('NAXIS3' in fixed_hdu_head)
+        self.assertFalse('CRVAL3' in fixed_hdu_head)
+        self.assertFalse('CRPIX3' in fixed_hdu_head)
+        self.assertFalse('CDELT3' in fixed_hdu_head)
+        self.assertFalse('CROTA3' in fixed_hdu_head)
+        self.assertFalse('NAXIS4' in fixed_hdu_head)
+        self.assertFalse('CRVAL4' in fixed_hdu_head)
+        self.assertFalse('CRPIX4' in fixed_hdu_head)
+        self.assertFalse('CDELT4' in fixed_hdu_head)
+        self.assertFalse('CROTA4' in fixed_hdu_head)
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.fits.open')
+    def test_fixImgAxisAndUnits_FluxScaleCorrection(self, mock_read, mock_write):
+        hdu = self._createDummyFITS(ndim=2)         # dummy 2D fits
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        # add flux scale headers
+        hdu.header['BZERO'] = 1500.0
+        hdu.header['BSCALE'] = 2.0
+        mock_read.return_value = fits.HDUList([hdu])
+
+        self.assertEqual(self.utils.fixImgAxisAndUnits(infile, outfile), 0)
+        assert mock_read.called
+        assert mock_write.called
+        fixed_hdu = mock_write.call_args[0]
+        fixed_hdu_data = fixed_hdu[0]
+        fixed_hdu_name = fixed_hdu[1]
+        fixed_hdu_head = fixed_hdu[2]
+
+        self.assertEqual(fixed_hdu_data.ndim, 2)        # check dimensions
+        self.assertEqual(fixed_hdu_data.shape, (512, 512))
+        self.assertEqual(fixed_hdu_name, outfile)       # check file name
+        self.assertEqual(fixed_hdu_head['NAXIS'], 2)    # check header
+        self.assertEqual(fixed_hdu_head['BSCALE'], 1)
+        self.assertEqual(fixed_hdu_head['BZERO'], 0)
+        self.assertAlmostEqual(fixed_hdu_data[0, 0] -
+                               hdu.data[0, 0], 1500+hdu.data[0, 0], places=1)   # check that output flux is BZERO+BSCALE*input flux
+
+    def test_fromBrightnessTempToJyBeam(self):
+        self.assertAlmostEqual(self.utils.fromBrightnessTempToJyBeam(
+            nu_GHz=90.5, bmin_arcsec=0.17, bmaj_arcsec=0.20), 0.0002278, places=5)
+        self.assertAlmostEqual(self.utils.fromBrightnessTempToJyBeam(
+            nu_GHz=230.5, bmin_arcsec=1.0, bmaj_arcsec=1.0), 0.043478, places=5)
+        self.assertAlmostEqual(self.utils.fromBrightnessTempToJyBeam(
+            nu_GHz=345.8, bmin_arcsec=19.5, bmaj_arcsec=19.5), 37.20, places=1)
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_convertImgToJyPixel_MissingHeaders(self, mock_read, mock_write):
+        hdu = self._createDummyFITS()
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        for keyword in ['BUNIT', 'CDELT1', 'CDELT2', 'CRPIX1', 'CRPIX2']:
+            header = copy.copy(hdu.header)
+            del header[keyword]
+            mock_read.return_value = (hdu.data, header)
+            with self.subTest(kw=keyword):
+                self.assertEqual(
+                    self.utils.convertImgToJyPixel(infile, outfile), -1)
+                assert mock_read.called
+                assert not mock_write.called
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_convertImgToJyPixel_UnitsJyBeam(self, mock_read, mock_write):
+        hdu = self._createDummyFITS(bunit='Jy/beam')
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        # beam info available
+        hdu.header['BMAJ'] = 0.01667
+        hdu.header['BMIN'] = 0.01667
+        mock_read.return_value = (hdu.data, hdu.header)
+        self.assertEqual(self.utils.convertImgToJyPixel(infile, outfile), 0)
+        assert mock_read.called
+        assert mock_write.called
+        fixed_hdu = mock_write.call_args[0]
+        fixed_hdu_data = fixed_hdu[0]
+        fixed_hdu_name = fixed_hdu[1]
+        fixed_hdu_head = fixed_hdu[2]
+        self.assertEqual(fixed_hdu_name, outfile)
+        self.assertEqual(fixed_hdu_head['BUNIT'], 'Jy/pixel')
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_convertImgToJyPixel_UnitsJyBeam_SurveyProvided(self, mock_read, mock_write):
+        hdu = self._createDummyFITS(bunit='Jy/beam')
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        # no beam info, survey provided
+        mock_read.return_value = (hdu.data, hdu.header)
+        self.assertEqual(self.utils.convertImgToJyPixel(
+            infile, outfile, 'nvss'), 0)
+        assert mock_read.called
+        assert mock_write.called
+        fixed_hdu = mock_write.call_args[0]
+        fixed_hdu_data = fixed_hdu[0]
+        fixed_hdu_name = fixed_hdu[1]
+        fixed_hdu_head = fixed_hdu[2]
+        self.assertEqual(fixed_hdu_name, outfile)
+        self.assertEqual(fixed_hdu_head['BUNIT'], 'Jy/pixel')
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_convertImgToJyPixel_UnitsJyBeam_NoBeamInfoNoSurvey(self, mock_read, mock_write):
+        hdu = self._createDummyFITS(bunit='Jy/beam')
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        mock_read.return_value = (hdu.data, hdu.header)
+        self.assertEqual(self.utils.convertImgToJyPixel(
+            infile, outfile, 'foo'), -1)
+
+        mock_read.return_value = (hdu.data, hdu.header)
+        self.assertEqual(self.utils.convertImgToJyPixel(
+            infile, outfile), -1)
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_convertImgToJyPixel_UnitsDN(self, mock_read, mock_write):
+        hdu = self._createDummyFITS(bunit='DN')
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        for wise_survey in ['wise_3_4', 'wise_4_6', 'wise_12', 'wise_22']:
+            with self.subTest():
+                header = copy.copy(hdu.header)
+                mock_read.return_value = (hdu.data, header)
+                mock_read.reset_mock()
+                mock_write.reset_mock()
+                self.assertEqual(self.utils.convertImgToJyPixel(
+                    infile, outfile, wise_survey), 0)
+                assert mock_read.called
+                assert mock_write.called
+                fixed_hdu = mock_write.call_args[0]
+                fixed_hdu_data = fixed_hdu[0]
+                fixed_hdu_name = fixed_hdu[1]
+                fixed_hdu_head = fixed_hdu[2]
+                self.assertEqual(fixed_hdu_name, outfile)
+                self.assertEqual(fixed_hdu_head['BUNIT'], 'Jy/pixel')
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_convertImgToJyPixel_UnitsMJysr(self, mock_read, mock_write):
+        hdu = self._createDummyFITS(bunit='MJy/sr')
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        mock_read.return_value = (hdu.data, hdu.header)
+        self.assertEqual(self.utils.convertImgToJyPixel(
+            infile, outfile), 0)
+        assert mock_read.called
+        assert mock_write.called
+        fixed_hdu = mock_write.call_args[0]
+        fixed_hdu_data = fixed_hdu[0]
+        fixed_hdu_name = fixed_hdu[1]
+        fixed_hdu_head = fixed_hdu[2]
+        self.assertEqual(fixed_hdu_name, outfile)
+        self.assertEqual(fixed_hdu_head['BUNIT'], 'Jy/pixel')
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_convertImgToJyPixel_UnitsWm2sr(self, mock_read, mock_write):
+        hdu = self._createDummyFITS(bunit='W/m^2-sr')
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        for msx_survey in ['msx_8_3', 'msx_12_1', 'msx_14_7', 'msx_21_3']:
+            with self.subTest():
+                mock_read.reset_mock()
+                mock_write.reset_mock()
+                header = copy.copy(hdu.header)
+                mock_read.return_value = (hdu.data, header)
+                self.assertEqual(self.utils.convertImgToJyPixel(
+                    infile, outfile, msx_survey), 0)
+                assert mock_read.called
+                assert mock_write.called
+                fixed_hdu = mock_write.call_args[0]
+                fixed_hdu_data = fixed_hdu[0]
+                fixed_hdu_name = fixed_hdu[1]
+                fixed_hdu_head = fixed_hdu[2]
+                self.assertEqual(fixed_hdu_name, outfile)
+                self.assertEqual(fixed_hdu_head['BUNIT'], 'Jy/pixel')
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_convertImgToJyPixel_UnitsK(self, mock_read, mock_write):
+        hdu = self._createDummyFITS(bunit='K')
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        # case 1: vgps
+        header = copy.copy(hdu.header)
+        mock_read.return_value = (hdu.data, header)
+        self.assertEqual(self.utils.convertImgToJyPixel(
+            infile, outfile, 'vgps'), 0)
+        assert mock_read.called
+        assert mock_write.called
+        fixed_hdu = mock_write.call_args[0]
+        fixed_hdu_data = fixed_hdu[0]
+        fixed_hdu_name = fixed_hdu[1]
+        fixed_hdu_head = fixed_hdu[2]
+        self.assertEqual(fixed_hdu_name, outfile)
+        self.assertEqual(fixed_hdu_head['BUNIT'], 'Jy/pixel')
+
+        # case 2: no survey
+        mock_read.reset_mock()
+        mock_write.reset_mock()
+        header = copy.copy(hdu.header)
+        mock_read.return_value = (hdu.data, header)
+        self.assertEqual(self.utils.convertImgToJyPixel(
+            infile, outfile), -1)
+        assert mock_read.called
+        assert not mock_write.called
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_convertImgToJyPixel_UnitsJypixel(self, mock_read, mock_write):
+        hdu = self._createDummyFITS(bunit='Jy/pixel')
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        # no conversion needed!
+        mock_read.return_value = (hdu.data, hdu.header)
+        self.assertEqual(self.utils.convertImgToJyPixel(
+            infile, outfile), 0)
+        assert mock_read.called
+        assert mock_write.called
+        fixed_hdu = mock_write.call_args[0]
+        fixed_hdu_data = fixed_hdu[0]
+        fixed_hdu_name = fixed_hdu[1]
+        fixed_hdu_head = fixed_hdu[2]
+        self.assertEqual(fixed_hdu_name, outfile)
+        # data should be identical
+        np.testing.assert_array_equal(fixed_hdu_data, hdu.data)
+        # and headers too!
+        self.assertEqual(fixed_hdu_head, hdu.header)
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_convertImgToJyPixel_UnitsUnknown(self, mock_read, mock_write):
+        hdu = self._createDummyFITS(bunit='counts')
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        mock_read.return_value = (hdu.data, hdu.header)
+        self.assertEqual(self.utils.convertImgToJyPixel(
+            infile, outfile), -1)
+        assert mock_read.called
+        assert not mock_write.called
+
+    @patch('utils.os')
+    @patch('utils.montage')
+    def test_makeMosaic_Success(self, mock_montage, mock_os):
+        outfile = '/out/mosaic.fits'
+        input_tbl = '/tmp/input_tbl.txt'
+
+        # setup montage methods
+        # mImgTbl output http://montage.ipac.caltech.edu/docs/mImgtbl.html
+        def mImgtbl_ret(): return 0
+        mImgtbl_ret.stat = 'OK'
+        mImgtbl_ret.count = 5
+        mImgtbl_ret.badfits = 0
+        mock_montage.mImgtbl.return_value = mImgtbl_ret
+
+        self.assertEqual(self.utils.makeMosaic(input_tbl, outfile),  0)
+        assert mock_montage.mImgtbl.called
+        assert mock_montage.mAdd.called
+        assert mock_montage.mConvert.called
+
+    @patch('utils.os')
+    @patch('utils.montage')
+    def test_makeMosaic_Success(self, mock_montage, mock_os):
+        outfile = '/out/mosaic.fits'
+        input_tbl = '/tmp/input_tbl.txt'
+
+        # setup montage methods
+        # mImgTbl output http://montage.ipac.caltech.edu/docs/mImgtbl.html
+        def mImgtbl_ret(): return 0
+        mImgtbl_ret.stat = 'OK'
+        mImgtbl_ret.count = 5
+        mImgtbl_ret.badfits = 0
+        mock_montage.mImgtbl.return_value = mImgtbl_ret
+
+        self.assertEqual(self.utils.makeMosaic(input_tbl, outfile),  0)
+        assert mock_montage.mImgtbl.called
+        assert mock_montage.mAdd.called
+        assert mock_montage.mConvert.called
+
+    @patch('utils.os')
+    @patch('utils.montage')
+    def test_makeMosaic_Success_BackgroundMatchNotOverlapping(self, mock_montage, mock_os):
+        outfile = '/out/mosaic.fits'
+        input_tbl = '/tmp/input_tbl.txt'
+
+        # setup montage methods
+        # mImgTbl output http://montage.ipac.caltech.edu/docs/mImgtbl.html
+        def mImgtbl_ret(): return 0
+        mImgtbl_ret.stat = 'OK'
+        mImgtbl_ret.count = 5
+        mImgtbl_ret.badfits = 0
+        mock_montage.mImgtbl.return_value = mImgtbl_ret
+
+        # mImgTbl output http://montage.ipac.caltech.edu/docs/mOverlaps.html
+        def mOverlaps_ret(): return 0
+        mOverlaps_ret.stat = 'OK'
+        mOverlaps_ret.count = 0
+        mock_montage.mOverlaps.return_value = mOverlaps_ret
+
+        self.assertEqual(self.utils.makeMosaic(
+            input_tbl, outfile, background_match=True),  0)
+        assert mock_montage.mImgtbl.called
+        assert mock_montage.mAdd.called
+        assert mock_montage.mConvert.called
+
+    @patch('utils.os')
+    @patch('utils.montage')
+    def test_makeMosaic_Success_BackgroundMatchNotImplemented(self, mock_montage, mock_os):
+        outfile = '/out/mosaic.fits'
+        input_tbl = '/tmp/input_tbl.txt'
+
+        # setup montage methods
+        # mImgTbl output http://montage.ipac.caltech.edu/docs/mImgtbl.html
+        def mImgtbl_ret(): return 0
+        mImgtbl_ret.stat = 'OK'
+        mImgtbl_ret.count = 5
+        mImgtbl_ret.badfits = 0
+        mock_montage.mImgtbl.return_value = mImgtbl_ret
+
+        # mImgTbl output http://montage.ipac.caltech.edu/docs/mOverlaps.html
+        def mOverlaps_ret(): return 0
+        mOverlaps_ret.stat = 'OK'
+        mOverlaps_ret.count = 1
+        mock_montage.mOverlaps.return_value = mOverlaps_ret
+
+        with self.assertRaises(NotImplementedError):
+            self.utils.makeMosaic(
+                input_tbl, outfile, background_match=True)
+
+    @patch('utils.os')
+    @patch('utils.montage')
+    def test_makeMosaic_NoImagesProjected(self, mock_montage, mock_os):
+        outfile = '/out/mosaic.fits'
+        input_tbl = '/tmp/input_tbl.txt'
+
+        # setup montage methods
+        # mImgTbl output http://montage.ipac.caltech.edu/docs/mImgtbl.html
+        def mImgtbl_ret(): return 0
+        mImgtbl_ret.stat = 'OK'
+        mImgtbl_ret.count = 0
+        mImgtbl_ret.badfits = 10
+        mock_montage.mImgtbl.return_value = mImgtbl_ret
+
+        self.assertEqual(self.utils.makeMosaic(input_tbl, outfile),  -1)
+        assert mock_montage.mImgtbl.called
+        assert not mock_montage.mAdd.called
+        assert not mock_montage.mConvert.called
+
+    @patch('utils.fits.HDUList.writeto', side_effect=Exception())
+    def test_write_fits(self, mockWrite):
+
+        hdu = self._createDummyFITS()
+        filename = 'test.fits'
+        with self.assertRaises(Exception):
+            utils.write_fits(None, None)
+
+    @patch('utils.fits.open')
+    def test_read_fits_Input2D(self, mock_read):
+        hdu = self._createDummyFITS()
+
+        mock_read.return_value = fits.HDUList([hdu])
+        data, header = self.utils.read_fits('test.fits')
+        assert mock_read.called
+        self.assertIsNotNone(data)
+        self.assertEqual(data.shape, (512, 512))
+
+    @patch('utils.fits.open')
+    def test_read_fits_Input4DFits(self, mock_read):
+        hdu = self._createDummyFITS(ndim=4)
+
+        mock_read.return_value = fits.HDUList([hdu])
+        data, header = self.utils.read_fits('test.fits')
+        assert mock_read.called
+        self.assertIsNotNone(data)
+        self.assertEqual(data.ndim, 2)
+        self.assertEqual(data.shape, (512, 512))
+
+    @patch('utils.fits.open')
+    def test_read_fits_InputInvalidChannels(self, mock_read):
+        hdu = self._createDummyFITS(ndim=5)
+
+        mock_read.return_value = fits.HDUList([hdu])
+
+        with self.assertRaises(IOError):
+            self.utils.read_fits('test.fits')
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_cropImage_BasicWorldUnits(self, mock_read, mock_write):
+        hdu = self._createDummyFITS()
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        mock_read.return_value = (hdu.data, hdu.header)
+
+        # crop size 1 arcmin == 10 pixels
+        self.assertEqual(self.utils.cropImage(
+            filename=infile, ra=0, dec=0, crop_size=1*u.arcmin, outfile=outfile), 0)
+        assert mock_read.called
+        assert mock_write.called
+        crop_hdu = mock_write.call_args[0]
+        crop_hdu_data = crop_hdu[0]
+        crop_hdu_name = crop_hdu[1]
+        self.assertEqual(crop_hdu_name, outfile)
+        self.assertEqual(crop_hdu_data.shape, (10, 10))
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_cropImage_BasicPixelUnits(self, mock_read, mock_write):
+        hdu = self._createDummyFITS()
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        mock_read.return_value = (hdu.data, hdu.header)
+
+        # crop size 10 pixels == 1 arcmin
+        self.assertEqual(self.utils.cropImage(
+            filename=infile, ra=0, dec=0, crop_size=10, outfile=outfile), 0)
+        assert mock_read.called
+        assert mock_write.called
+        crop_hdu = mock_write.call_args[0]
+        crop_hdu_data = crop_hdu[0]
+        crop_hdu_name = crop_hdu[1]
+        self.assertEqual(crop_hdu_name, outfile)
+        self.assertEqual(crop_hdu_data.shape, (10, 10))
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_cropImage_CropLargerThanImage(self, mock_read, mock_write):
+        hdu = self._createDummyFITS()
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        mock_read.return_value = (hdu.data, hdu.header)
+
+        # crop size 10% larger than image size
+        self.assertEqual(self.utils.cropImage(
+            filename=infile, ra=0, dec=0, crop_size=1.1*hdu.data.shape[0], outfile=outfile, nanfill=False), 0)
+        assert mock_read.called
+        assert mock_write.called
+        crop_hdu = mock_write.call_args[0]
+        crop_hdu_data = crop_hdu[0]
+        crop_hdu_name = crop_hdu[1]
+        self.assertEqual(crop_hdu_name, outfile)
+        self.assertGreater(crop_hdu_data.shape, hdu.data.shape)
+        assert np.isnan(crop_hdu_data).any()    # should contain NaNs
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_cropImage_CropLargerThanImage_FillWithValue(self, mock_read, mock_write):
+        hdu = self._createDummyFITS()
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        mock_read.return_value = (hdu.data, hdu.header)
+
+        # crop size 10% larger than image size
+        self.assertEqual(self.utils.cropImage(
+            filename=infile, ra=0, dec=0, crop_size=1.1*hdu.data.shape[0], outfile=outfile, nanfill=True, nanfill_mode='', nanfill_val=999), 0)
+        assert mock_read.called
+        assert mock_write.called
+        crop_hdu = mock_write.call_args[0]
+        crop_hdu_data = crop_hdu[0]
+        crop_hdu_name = crop_hdu[1]
+        self.assertEqual(crop_hdu_name, outfile)
+        self.assertGreater(crop_hdu_data.shape, hdu.data.shape)
+        assert not np.isnan(crop_hdu_data).any()    # should NOT contain NaNs
+        assert np.isin(999, crop_hdu_data).any()    # but fillval instead
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_cropImage_CropLargerThanImage_FillWithMin(self, mock_read, mock_write):
+        hdu = self._createDummyFITS(bkg_std=0)  # constant image
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        mock_read.return_value = (hdu.data, hdu.header)
+
+        # crop size 10% larger than image size
+        self.assertEqual(self.utils.cropImage(
+            filename=infile, ra=0, dec=0, crop_size=1.1*hdu.data.shape[0], outfile=outfile, nanfill=True, nanfill_mode='imgmin', nanfill_val=999), 0)
+        assert mock_read.called
+        assert mock_write.called
+        crop_hdu = mock_write.call_args[0]
+        crop_hdu_data = crop_hdu[0]
+        crop_hdu_name = crop_hdu[1]
+        self.assertEqual(crop_hdu_name, outfile)
+        self.assertGreater(crop_hdu_data.shape, hdu.data.shape)
+        assert not np.isnan(crop_hdu_data).any()  # should NOT contain NaNs
+        # all values = 0, so min = 0 (fill value ignored)
+        assert np.isin(0, crop_hdu_data).all()
+
+    @patch('utils.Utils.write_fits')
+    @patch('utils.Utils.read_fits')
+    def test_cropImage_CropLargerThanSourceSize(self, mock_read, mock_write):
+        hdu = self._createDummyFITS()
+        infile = 'test_in.fits'
+        outfile = 'test_out.fits'
+
+        mock_read.return_value = (hdu.data, hdu.header)
+
+        self.assertEqual(self.utils.cropImage(
+            filename=infile, ra=0, dec=0, crop_size=10, source_size=20, outfile=outfile, nanfill=False), -1)
+        assert mock_read.called
+        assert not mock_write.called
+
+    @patch('utils.fits.open')
+    def test_estimateBkgFromAnnulus_PositiveBkg(self, mock_read):
+        bkg = 1.0
+        hdu = self._createDummyFITS(size=512, bkg_mean=bkg)
+
+        mock_read.return_value = fits.HDUList([hdu])
+
+        # using sigma clip
+        bkg_annulus = self.utils.estimateBkgFromAnnulus(
+            'test.fits', 0, 0, 12, 24, method='sigmaclip')
+        self.assertGreater(bkg_annulus, 0)
+        self.assertAlmostEqual(bkg_annulus, bkg, places=0)
+
+        # using median
+        bkg_annulus = self.utils.estimateBkgFromAnnulus(
+            'test.fits', 0, 0, 12, 24, method='median')
+        self.assertGreater(bkg_annulus, 0)
+        self.assertAlmostEqual(bkg_annulus, bkg, places=0)
+
+        assert mock_read.called
+
+    @patch('utils.fits.open')
+    def test_estimateBkgFromAnnulus_NegativeBkg(self, mock_read):
+        bkg = -1.0
+        hdu = self._createDummyFITS(size=512, bkg_mean=bkg)
+
+        mock_read.return_value = fits.HDUList([hdu])
+
+        bkg_annulus = self.utils.estimateBkgFromAnnulus(
+            'test.fits', 0, 0, 12, 24, method='sigmaclip')
+        self.assertLess(bkg_annulus, 0)
+        self.assertAlmostEqual(bkg_annulus, bkg, places=0)
+
+        # using median
+        bkg_annulus = self.utils.estimateBkgFromAnnulus(
+            'test.fits', 0, 0, 12, 24, method='median')
+        self.assertLess(bkg_annulus, 0)
+        self.assertAlmostEqual(bkg_annulus, bkg, places=0)
+
+        mock_read.assert_called()
+
+    @patch('utils.fits.open')
+    def test_estimateBkgFromAnnulus_WithSource(self, mock_read):
+        bkg = 1.0
+        src = 5.0   # src brigthness
+        hdu = self._createDummyFITS(size=512, bkg_mean=bkg)
+
+        # simulate extended src of 12x12 px
+        sou_size = 6
+        hdu.data[250:262, 250:262] = src
+        mock_read.return_value = fits.HDUList([hdu])
+        self.assertAlmostEqual(self.utils.estimateBkgFromAnnulus(
+            'test.fits', 0, 0, 12, 24), src, places=0)  # annulus within src
+        self.assertAlmostEqual(self.utils.estimateBkgFromAnnulus(
+            'test.fits', 0, 0, 42, 48), bkg, places=0)  # annulus outside src
+        mock_read.assert_called()
+
+    @patch('utils.fits.open')
+    def test_estimateBkgFromAnnulus_WithSourceAndLargeRms(self, mock_read):
+        bkg = 1.0
+        src = 5.0   # src brigthness
+
+        # highly variable background (up to 80% of srcbrigthness)
+        hdu = self._createDummyFITS(size=512, bkg_mean=bkg, bkg_std=0.8*src)
+
+        # simulate extended src of 12x12 px
+        sou_size = 6
+        hdu.data[250:262, 250:262] = 5.0
+
+        # TODO: improve testing (e.g. annulus overlapping w/ src, etc)
+        mock_read.return_value = fits.HDUList([hdu])
+        self.assertAlmostEqual(self.utils.estimateBkgFromAnnulus(
+            'test.fits', 0, 0, 12, 24), 5.0, places=0)  # annulus within src
+        self.assertLess(self.utils.estimateBkgFromAnnulus(
+            'test.fits', 0, 0, 42, 48), src)       # annulus outside src
+        mock_read.assert_called()
+
+    @patch('utils.fits.open')
+    def test_estimateBkgFromAnnulus_OutOfBounds(self, mock_read):
+        bkg = 1.0
+        hdu = self._createDummyFITS(size=512, bkg_mean=bkg)
+        mock_read.return_value = fits.HDUList([hdu])
+        self.assertEqual(self.utils.estimateBkgFromAnnulus(
+            'test.fits', 1, 1, 12, 24), 0)     # Out of bounds => all pixels masked
+        mock_read.assert_called()
+
+    @patch('utils.fits.open')
+    def test_estimateBkgFromAnnulus_UnknownMethod(self, mock_read):
+        bkg = 1.0
+        hdu = self._createDummyFITS(size=512, bkg_mean=bkg)
+        mock_read.return_value = fits.HDUList([hdu])
+        self.assertEqual(self.utils.estimateBkgFromAnnulus(
+            'test.fits', 0, 0, 12, 24, method='unknown'), -1)
+        mock_read.assert_called()


### PR DESCRIPTION
Unit test battery for most of the methods in the 'utils' package. Current code coverage at 88%.

- I did not test "wrapper" methods for OS functions (creating dirs, finding files and so on)
- FITS-related R/W operations, as well as calls to external processes (e.g. montage), are mocked.
- All basic functionality is tested. However, we need to discuss with @mbufano additional test cases as well as perform functional tests.
- I noticed that montage outputs (status code and image counts) are only checked when calling 'mImgtbl' and 'mOverlaps', so I only mocked the return values of these functions. We could check that every other method executes correctly (for the sake of safety).


To run tests, cd into scutout directory and type:

`python -m unittest -v tests.test_utils
`

or, if coverage library is installed:

`coverage run --source=scutout -m unittest -v tests.test_utils
`

and then

`coverage html
`

I also added a .gitignore file.

Please find the coverage report attached:

[coverage.zip](https://github.com/SKA-INAF/scutout/files/4564134/coverage.zip)
