### PR TITLE
Fixes unintended brightness scale inversion in MIPS and MSX surveys

### DIFF
--- a/scutout/utils.py
+++ b/scutout/utils.py
@@ -728,8 +728,8 @@ class Utils(object):
             return -1
 
         units = header['BUNIT']
-        dx = header['CDELT1']  # in deg
-        dy = header['CDELT2']  # in deg
+        dx = abs(header['CDELT1'])  # in deg
+        dy = abs(header['CDELT2'])  # in deg
         xc = header['CRPIX1']
         yc = header['CRPIX2']
         ra, dec = wcs.all_pix2world(xc, yc, 0, ra_dec_order=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -505,6 +505,9 @@ class UtilsTest(unittest.TestCase):
                 fixed_hdu_head = fixed_hdu[2]
                 self.assertEqual(fixed_hdu_name, outfile)
                 self.assertEqual(fixed_hdu_head['BUNIT'], 'Jy/pixel')
+                # position of maxima should match (just scaling)
+                self.assertEqual(np.argmax(fixed_hdu_data),
+                                 np.argmax(hdu.data))
 
     @patch('utils.Utils.write_fits')
     @patch('utils.Utils.read_fits')
@@ -524,6 +527,8 @@ class UtilsTest(unittest.TestCase):
         fixed_hdu_head = fixed_hdu[2]
         self.assertEqual(fixed_hdu_name, outfile)
         self.assertEqual(fixed_hdu_head['BUNIT'], 'Jy/pixel')
+        # position of maxima should match (just scaling)
+        self.assertEqual(np.argmax(fixed_hdu_data), np.argmax(hdu.data))
 
     @patch('utils.Utils.write_fits')
     @patch('utils.Utils.read_fits')
@@ -548,6 +553,9 @@ class UtilsTest(unittest.TestCase):
                 fixed_hdu_head = fixed_hdu[2]
                 self.assertEqual(fixed_hdu_name, outfile)
                 self.assertEqual(fixed_hdu_head['BUNIT'], 'Jy/pixel')
+                # position of maxima should match (just scaling)
+                self.assertEqual(np.argmax(fixed_hdu_data),
+                                 np.argmax(hdu.data))
 
     @patch('utils.Utils.write_fits')
     @patch('utils.Utils.read_fits')
@@ -569,6 +577,8 @@ class UtilsTest(unittest.TestCase):
         fixed_hdu_head = fixed_hdu[2]
         self.assertEqual(fixed_hdu_name, outfile)
         self.assertEqual(fixed_hdu_head['BUNIT'], 'Jy/pixel')
+        # position of maxima should match (just scaling)
+        self.assertEqual(np.argmax(fixed_hdu_data), np.argmax(hdu.data))
 
         # case 2: no survey
         mock_read.reset_mock()
@@ -577,6 +587,8 @@ class UtilsTest(unittest.TestCase):
         mock_read.return_value = (hdu.data, header)
         self.assertEqual(self.utils.convertImgToJyPixel(
             infile, outfile), -1)
+        # position of maxima should match (just scaling)
+        self.assertEqual(np.argmax(fixed_hdu_data), np.argmax(hdu.data))
         assert mock_read.called
         assert not mock_write.called
 


### PR DESCRIPTION
In the method 'convertImgToJyPixel', the CDELT header values are used to compute the conversion factor for MIPS and MSX data.

However, CDELT1 is usually negative. This caused convFactor to become negative as well, inverting the brightness scale of the output FITS.

Added an additional condition to the tests to check for this issue: that the "peak" position remains the same between the input and output images.