### PR TITLE
Fixes brigthness conversion factor for MIPS and MSX surveys

### DIFF
--- a/scutout/utils.py
+++ b/scutout/utils.py
@@ -775,11 +775,13 @@ class Utils(object):
 
         # - MJy/sr units (e.g. HERSCHEL/SPITZER maps)
         elif units == 'MJy/sr':
-            convFactor = 1.e+6*dx*dy/(206265.*206265.)
+            # we need dx and dy in ''
+            convFactor = 1.e+6*(3600*dx)*(3600*dy)/(206265.*206265.)
 
         # - W/m^2-sr units (e.g. MSX maps)
         elif units == 'W/m^2-sr':
-            convFactor_fromJyToSr = dx*dy/(206265.*206265.)
+            # we need dx and dy in ''
+            convFactor_fromJyToSr = (3600*dx)*(3600*dy)/(206265.*206265.)
             if survey == 'msx_8_3':
                 convFactor = 7.133e+12*convFactor_fromJyToSr
             elif survey == 'msx_12_1':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -649,25 +649,6 @@ class UtilsTest(unittest.TestCase):
 
     @patch('utils.os')
     @patch('utils.montage')
-    def test_makeMosaic_Success(self, mock_montage, mock_os):
-        outfile = '/out/mosaic.fits'
-        input_tbl = '/tmp/input_tbl.txt'
-
-        # setup montage methods
-        # mImgTbl output http://montage.ipac.caltech.edu/docs/mImgtbl.html
-        def mImgtbl_ret(): return 0
-        mImgtbl_ret.stat = 'OK'
-        mImgtbl_ret.count = 5
-        mImgtbl_ret.badfits = 0
-        mock_montage.mImgtbl.return_value = mImgtbl_ret
-
-        self.assertEqual(self.utils.makeMosaic(input_tbl, outfile),  0)
-        assert mock_montage.mImgtbl.called
-        assert mock_montage.mAdd.called
-        assert mock_montage.mConvert.called
-
-    @patch('utils.os')
-    @patch('utils.montage')
     def test_makeMosaic_Success_BackgroundMatchNotOverlapping(self, mock_montage, mock_os):
         outfile = '/out/mosaic.fits'
         input_tbl = '/tmp/input_tbl.txt'


### PR DESCRIPTION
The conversion from MIPS and MSX native units to Jy/px is considering the arcsec/rad factor, but CDELT comes in deg/px units. Thus, dx and dy must be converted to arcsec (x3600).