### PR TITLE
Removes non-significant trailing spaces in BUNIT header

### DIFF
--- a/scutout/utils.py
+++ b/scutout/utils.py
@@ -727,12 +727,9 @@ class Utils(object):
                          filename + ", cannot compute conversion factor!")
             return -1
 
-        units = header['BUNIT']
+        units = header['BUNIT'].strip()
         dx = abs(header['CDELT1'])  # in deg
         dy = abs(header['CDELT2'])  # in deg
-        xc = header['CRPIX1']
-        yc = header['CRPIX2']
-        ra, dec = wcs.all_pix2world(xc, yc, 0, ra_dec_order=True)
 
         # ==================
         # - Convert data
@@ -741,6 +738,9 @@ class Utils(object):
 
         # - Jy/beam units (e.g. radio maps, apex)
         if units == 'JY/BEAM' or units == 'Jy/beam':
+            xc = header['CRPIX1']
+            yc = header['CRPIX2']
+            ra, dec = wcs.all_pix2world(xc, yc, 0, ra_dec_order=True)
 
             hasBeamInfo = Utils.hasBeamInfo(header)
             if hasBeamInfo:


### PR DESCRIPTION
Some surveys (e.g. Herschel, VGPS) have trailing tabs or white spaces in the 'BUNIT' header. FITS 3.0 standard states that these trailing spaces are not significant, but some versions of astropy treat them as significant. We have to remove them manually to ensure that the units are properly identified.

Besides, WCS from HiGal data does not have 'RA' information, causing the all_pix2world call to fail.  I have moved the call to the Jy/beam block (the only place where it is actually needed).