### PR TITLE
Minor fixes on header treatment and beam corrections

### DIFF
--- a/scutout/cutout_extractor.py
+++ b/scutout/cutout_extractor.py
@@ -399,12 +399,12 @@ class CutoutHelper(object):
 		
 		for index in range(len(raw_cutouts)):
 			data, header= Utils.read_fits(raw_cutouts[index])
-			dx= header['CDELT1']
-			dy= header['CDELT2']
+			dx= abs(header['CDELT1'])
+			dy= abs(header['CDELT2'])
 		
 			data_reproj, header_reproj= Utils.read_fits(reproj_cutouts[index])
-			dx_reproj= header_reproj['CDELT1']
-			dy_reproj= header_reproj['CDELT2']
+			dx_reproj= abs(header_reproj['CDELT1'])
+			dy_reproj= abs(header_reproj['CDELT2'])
 
 			flux_scale= (dx_reproj/dx)*(dy_reproj/dy)
 			data_reproj_scaled= flux_scale*data_reproj
@@ -414,7 +414,7 @@ class CutoutHelper(object):
 			if Utils.hasBeamInfo(header) and not Utils.hasBeamInfo(header_reproj):
 				header_reproj['BMAJ']= header['BMAJ']
 				header_reproj['BMIN']= header['BMIN']
-				header_reproj['BPA']= header['BPA']
+				header_reproj['BPA']= header['BPA'] if 'BPA' in header else 0.
 
 			Utils.write_fits(data_reproj_scaled,reproj_cutouts[index],header_reproj)
 			
@@ -466,15 +466,15 @@ class CutoutHelper(object):
 			xc= header['CRPIX1']
 			yc= header['CRPIX2']	
 			ra, dec = wcs.all_pix2world(xc,yc,0,ra_dec_order=True)
-			dx= header['CDELT1'] # in deg
-			dy= header['CDELT2'] # in deg
+			dx= abs(header['CDELT1']) # in deg
+			dy= abs(header['CDELT2']) # in deg
 			pixsize_x.append(dx)
 			pixsize_y.append(dy)
 
 			if hasBeamInfo:
 				bmaj= header['BMAJ'] # in deg
 				bmin= header['BMIN'] # in deg
-				pa= header['BPA'] # in deg
+				pa= header['BPA'] if 'BPA' in header else 0 # in deg
 				beam= radio_beam.Beam(bmaj*u.deg,bmin*u.deg,pa*u.deg)
 			else:
 				logger.warn("No BMAJ/BMIN keyword present in file " + path + ", trying to retrieve from survey name...")

--- a/scutout/utils.py
+++ b/scutout/utils.py
@@ -262,18 +262,18 @@ class Utils(object):
     @classmethod
     def getWiseSurveyBeamArea(cls, band):
         """ Returns Wise survey beam area """
-        if band == 'wise_3_4':
-            bmaj = 8.5  # arcsec
-            bmin = 8.5  # arcsec
+        if band == 'wise_3_4':     # http://wise2.ipac.caltech.edu/docs/release/allsky/  (Wrigth+10)
+            bmaj = 6.1  # arcsec
+            bmin = 6.1  # arcsec
         elif band == 'wise_4_6':
-            bmaj = 8.5  # arcsec
-            bmin = 8.5  # arcsec
+            bmaj = 6.4  # arcsec
+            bmin = 6.4  # arcsec
         elif band == 'wise_12':
-            bmaj = 8.5  # arcsec
-            bmin = 8.5  # arcsec
+            bmaj = 6.5  # arcsec
+            bmin = 6.5  # arcsec
         elif band == 'wise_22':
-            bmaj = 17  # arcsec
-            bmin = 17  # arcsec
+            bmaj = 12  # arcsec
+            bmin = 12  # arcsec
         else:
             logger.error("Invalid/unknown band argument given (" + band + ")!")
             return 0
@@ -311,7 +311,8 @@ class Utils(object):
     def getMIPSSurveyBeamArea(cls):
         """ Returns MIPS survey beam area """
 
-        bmaj = 6  # arcsec
+        # arcsec    Rieke+04 (https://iopscience.iop.org/article/10.1086/422717/pdf)
+        bmaj = 6
         bmin = 6  # arcsec
         bmaj_deg = bmaj/3600.
         bmin_deg = bmin/3600.
@@ -322,20 +323,20 @@ class Utils(object):
     def getHiGalSurveyBeamArea(cls, band):
         """ Returns HiGal survey beam area """
         if band == 'higal_70':
-            bmaj = 8.512  # arcsec
-            bmin = 8.512  # arcsec
+            bmaj = 6.7  # arcsec	https://hi-gal.iaps.inaf.it/ ; Bufano+18
+            bmin = 6.7  # arcsec
         elif band == 'higal_160':
-            bmaj = 12.103  # arcsec
-            bmin = 12.103  # arcsec
+            bmaj = 11.  # arcsec
+            bmin = 11.  # arcsec
         elif band == 'higal_250':
-            bmaj = 18  # arcsec
-            bmin = 18  # arcsec
+            bmaj = 18.  # arcsec
+            bmin = 18.  # arcsec
         elif band == 'higal_350':
-            bmaj = 24  # arcsec
-            bmin = 24  # arcsec
+            bmaj = 25.  # arcsec
+            bmin = 25.  # arcsec
         elif band == 'higal_500':
-            bmaj = 34.5  # arcsec
-            bmin = 34.5  # arcsec
+            bmaj = 37.  # arcsec
+            bmin = 37.  # arcsec
         else:
             logger.error("Invalid/unknown band argument given (" + band + ")!")
             return 0
@@ -376,7 +377,7 @@ class Utils(object):
     def getMSXSurveyBeamArea(cls):
         """ Returns MSX survey beam area """
 
-        bmaj = 20  # arcsec
+        bmaj = 20  # arcsec	http://irsa.ipac.caltech.edu/applications/MSX/MSX/imageDescriptions.htm
         bmin = 20  # arcsec
         bmaj_deg = bmaj/3600.
         bmin_deg = bmin/3600.
@@ -740,7 +741,12 @@ class Utils(object):
         if units == 'JY/BEAM' or units == 'Jy/beam':
             xc = header['CRPIX1']
             yc = header['CRPIX2']
-            ra, dec = wcs.all_pix2world(xc, yc, 0, ra_dec_order=True)
+            try:
+                ra, dec = wcs.all_pix2world(xc, yc, 0, ra_dec_order=True)
+            except Exception:
+                ra, dec = (0, 0)
+                logger.warning(
+                    "Cannot compute RA, Dec from WCS header, assuming (0,0)")
 
             hasBeamInfo = Utils.hasBeamInfo(header)
             if hasBeamInfo:
@@ -774,7 +780,7 @@ class Utils(object):
                 return -1
 
         # - MJy/sr units (e.g. HERSCHEL/SPITZER maps)
-        elif units == 'MJy/sr':
+        elif units.startswith('MJy/sr'):
             # we need dx and dy in ''
             convFactor = 1.e+6*(3600*dx)*(3600*dy)/(206265.*206265.)
 
@@ -833,8 +839,8 @@ class Utils(object):
         # - Read fits image
         data, header = Utils.read_fits(filename)
         wcs = WCS(header)
-        dx = header['CDELT1']  # in deg
-        dy = header['CDELT2']  # in deg
+        dx = abs(header['CDELT1'])  # in deg
+        dy = abs(header['CDELT2'])  # in deg
         pix_size = max(dx, dy)  # in deg
 
         # - Check if crop size is cutting part of the source

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,13 +142,13 @@ class UtilsTest(unittest.TestCase):
 
     def test_getWiseSurveyBeamArea(self):
         self.assertEqual(self.utils.getWiseSurveyBeamArea(
-            band='wise_3_4'),  6.316802088098279e-06)
+            band='wise_3_4'),  3.2532623626039716e-06)
         self.assertEqual(self.utils.getWiseSurveyBeamArea(
-            band='wise_4_6'),  6.316802088098279e-06)
+            band='wise_4_6'),  3.581124062678277e-06)
         self.assertEqual(self.utils.getWiseSurveyBeamArea(
-            band='wise_12'),  6.316802088098279e-06)
+            band='wise_12'),  3.6939084875038367e-06)
         self.assertEqual(self.utils.getWiseSurveyBeamArea(
-            band='wise_22'),  2.5267208352393116e-05)
+            band='wise_22'),  1.2589889282853316e-05)
         self.assertEqual(self.utils.getWiseSurveyBeamArea(band='no_band'),  0)
         self.assertEqual(self.utils.getWiseSurveyBeamArea(band=''),  0)
 
@@ -170,15 +170,15 @@ class UtilsTest(unittest.TestCase):
 
     def test_getHiGalSurveyBeamArea(self):
         self.assertEqual(self.utils.getHiGalSurveyBeamArea(
-            band='higal_70'), 6.334650354471603e-06)
+            band='higal_70'), 3.924723124356149e-06)
         self.assertEqual(self.utils.getHiGalSurveyBeamArea(
-            band='higal_160'), 1.2806943258149252e-05)
+            band='higal_160'), 1.0579004189064245e-05)
         self.assertEqual(self.utils.getHiGalSurveyBeamArea(
             band='higal_250'), 2.8327250886419965e-05)
         self.assertEqual(self.utils.getHiGalSurveyBeamArea(
-            band='higal_350'), 5.0359557131413266e-05)
+            band='higal_350'), 5.464361667905085e-05)
         self.assertEqual(self.utils.getHiGalSurveyBeamArea(
-            band='higal_500'), 0.00010406330360358443)
+            band='higal_500'), 0.00011969137797379301)
         self.assertEqual(self.utils.getIRACSurveyBeamArea(band='no_band'),  0)
         self.assertEqual(self.utils.getHiGalSurveyBeamArea(band=''),  0)
 
@@ -224,13 +224,13 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(self.utils.getSurveyBeamArea(
             'vgps'), 0.00017704531804012478)
         self.assertEqual(self.utils.getSurveyBeamArea(
-            'wise_3_4'), 6.316802088098279e-06)
+            'wise_3_4'), 3.2532623626039716e-06)
         self.assertEqual(self.utils.getSurveyBeamArea(
-            'wise_4_6'), 6.316802088098279e-06)
+            'wise_4_6'), 3.581124062678277e-06)
         self.assertEqual(self.utils.getSurveyBeamArea(
-            'wise_12'), 6.316802088098279e-06)
+            'wise_12'), 3.6939084875038367e-06)
         self.assertEqual(self.utils.getSurveyBeamArea(
-            'wise_22'), 2.5267208352393116e-05)
+            'wise_22'), 1.2589889282853316e-05)
         self.assertEqual(self.utils.getSurveyBeamArea(
             'irac_3_6'), 2.526720835239311e-07)
         self.assertEqual(self.utils.getSurveyBeamArea(
@@ -242,15 +242,15 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual(self.utils.getSurveyBeamArea(
             'mips_24'), 3.147472320713329e-06)
         self.assertEqual(self.utils.getSurveyBeamArea(
-            'higal_70'), 6.334650354471603e-06)
+            'higal_70'), 3.924723124356149e-06)
         self.assertEqual(self.utils.getSurveyBeamArea(
-            'higal_160'), 1.2806943258149252e-05)
+            'higal_160'), 1.0579004189064245e-05)
         self.assertEqual(self.utils.getSurveyBeamArea(
             'higal_250'), 2.8327250886419965e-05)
         self.assertEqual(self.utils.getSurveyBeamArea(
-            'higal_350'), 5.0359557131413266e-05)
+            'higal_350'), 5.464361667905085e-05)
         self.assertEqual(self.utils.getSurveyBeamArea(
-            'higal_500'), 0.00010406330360358443)
+            'higal_500'), 0.00011969137797379301)
         self.assertEqual(self.utils.getSurveyBeamArea(
             'atlasgal'),  3.0247209002055094e-05)
         self.assertEqual(self.utils.getSurveyBeamArea(


### PR DESCRIPTION
We have been fixing some issues concerning:
- CDELT keyword usage, which may cause negative conversion factors.
- Missing header keywords (e.g. BPA) causing unexpected crashes for some surveys.
- Wrong bmaj/bmin values for some surveys (WISE, HiGAL...)