### PR TITLE
Mosaicking improvements and progress bar

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -12,8 +12,9 @@ convert_to_jy_pixel= yes 						; To convert cutout image units in Jy/pixels
 subtract_bkg = no										; Subtract background (done before reprojection)
 regrid = yes 												; To regrid cutouts to same projection (aligned to North)
 convolve = yes 											; To convolve cutouts to same resolution
-crop = yes 													; To crop cutouts around source position to have final images with same number of pixels
-crop_size = 200 										; Cropped image size in pixels
+crop_mode = factor 										; To crop cutouts around source position {none,pixel,factor}
+crop_size = 1.2 										; Cropped image size (in pixels if mode 'pixel', as a factor of source radius if mode 'factor')
+
 
 [BKG_SUBTRACTION]
 bkg_estimator = sigmaclip						; Bkg estimator {median,sigmaclip}

--- a/scutout/config.py
+++ b/scutout/config.py
@@ -63,7 +63,7 @@ class Config(object):
 		self.subtract_bkg= False
 		self.regrid= True
 		self.convolve= True
-		self.crop= True
+		self.crop_mode= 'none'
 		self.crop_size= 200 # in pixels
 
 		# - Background calculation
@@ -288,13 +288,15 @@ class Config(object):
 		if self.parser.has_option('CUTOUT_SEARCH', 'convolve'):
 			self.convolve= self.parser.getboolean('CUTOUT_SEARCH', 'convolve') 
 		
-		if self.parser.has_option('CUTOUT_SEARCH', 'crop'):
-			self.crop= self.parser.getboolean('CUTOUT_SEARCH', 'crop')
+		if self.parser.has_option('CUTOUT_SEARCH', 'crop_mode'):
+			option_value= self.parser.get('CUTOUT_SEARCH', 'crop_mode')
+			if option_value:
+				self.crop_mode = option_value
 
 		if self.parser.has_option('CUTOUT_SEARCH', 'crop_size'):
 			option_value= self.parser.get('CUTOUT_SEARCH', 'crop_size')
 			if option_value:
-				self.crop_size= int(option_value)
+				self.crop_size= float(option_value)
 
 		# - Parse background options
 		if self.parser.has_option('BKG_SUBTRACTION', 'bkg_estimator'):


### PR DESCRIPTION
Some relatively big changes:

- "Double" cutout factor, to avoid weird geometries after reprojection when combining surveys with different orientations (e.g. diamond-like cutouts). E.g. first, a large cutout is made, then the resulting file is reprojected, and finally a second, smaller cutout is made. However, this is provisional, we should find a more elegant solution for this.

- Added a progress bar. The tool takes eons when cropping 100s of sources, so this is useful. It can be removed in the future when converting scutout into a service, or kept only for the CLI version.

- Read BUNIT from metadata table and pass it to convertImgToJyPixel to avoid errors due to missing BUNIT after mosaicking.